### PR TITLE
Fix react-chartjs-2 version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "react-dom": "18.2.0",
     "lucide-react": "^0.379.0",
     "chart.js": "^4.4.1",
-    "react-chartjs-2": "^5.3.1"
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@types/node": "22.15.30",


### PR DESCRIPTION
## Summary
- update `react-chartjs-2` to a valid version so `npm install` can run

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686a5650514883238d3096d26e11e4d1