### PR TITLE
Add history page and translations

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -31,6 +31,8 @@
   "scoreChart": "Score Chart",
   "cardView": "Card View",
   "tableView": "Table View",
-  "visualAnalysis": "Visual Analysis"
-  ,"share": "Share"
+  "visualAnalysis": "Visual Analysis",
+  "share": "Share",
+  "historyTitle": "History",
+  "deleteHistory": "Delete"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -31,6 +31,8 @@
   "scoreChart": "スコアチャート",
   "cardView": "カード表示",
   "tableView": "テーブル表示",
-  "visualAnalysis": "ビジュアル分析"
-  ,"share": "共有"
+  "visualAnalysis": "ビジュアル分析",
+  "share": "共有",
+  "historyTitle": "履歴",
+  "deleteHistory": "削除"
 }

--- a/web/pages/history.tsx
+++ b/web/pages/history.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+interface HistoryEntry {
+  id: string;
+  data: any;
+}
+
+export default function HistoryPage() {
+  const t = useTranslations();
+  const [items, setItems] = useState<HistoryEntry[]>([]);
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  const loadHistory = async () => {
+    try {
+      const res = await fetch(`${apiUrl}/history`);
+      if (res.ok) {
+        const data = await res.json();
+        setItems(data);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await fetch(`${apiUrl}/history/${id}`, { method: 'DELETE' });
+      setItems(items.filter((i) => i.id !== id));
+    } catch {
+      /* ignore */
+    }
+  };
+
+  useEffect(() => {
+    loadHistory();
+  }, []);
+
+  return (
+    <div className="max-w-[1100px] mx-auto px-4 space-y-4">
+      <h1 className="text-3xl font-bold">{t('historyTitle')}</h1>
+      {items.length === 0 ? (
+        <p>{t('noResults')}</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id} className="flex justify-between items-center bg-white p-2 rounded shadow">
+              <Link href={`/results?id=${item.id}`} className="text-blue-600 hover:underline">
+                {item.data && item.data[0]?.name ? item.data[0].name : item.id}
+              </Link>
+              <button onClick={() => handleDelete(item.id)} className="text-red-600 hover:underline">
+                {t('deleteHistory')}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -6,7 +6,10 @@ export default function Home() {
       <section className="space-y-6 pt-20">
         <h1 className="text-5xl font-bold">あらゆる『迷い』に、明確な答えを。</h1>
         <p className="text-lg">複数の選択肢を、あなただけの評価基準で簡単にランキング。直感的なビジュアル分析で、最適な選択をサポートします。</p>
-        <Link href="/create" className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark text-xl">無料でランキングを作成する</Link>
+        <div className="flex justify-center gap-4">
+          <Link href="/create" className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark text-xl">無料でランキングを作成する</Link>
+          <Link href="/history" className="inline-block px-6 py-3 bg-gray-600 text-white rounded-lg hover:bg-gray-700 text-xl">履歴を見る</Link>
+        </div>
       </section>
       <section className="space-y-8">
         <h2 className="text-3xl font-bold">たった3ステップで、意思決定をサポート</h2>

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -166,6 +166,12 @@ export default function Results() {
         <SaveHistoryButton data={results} />
         <ShareButton data={results} />
         <button
+          onClick={() => router.push('/history')}
+          className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          {t('historyTitle')}
+        </button>
+        <button
           onClick={goHome}
           className="px-3 py-1 bg-gray-600 text-white rounded hover:bg-gray-700"
         >


### PR DESCRIPTION
## Summary
- create `history.tsx` page to list saved rankings
- link to history from home and results pages
- localize new messages `historyTitle` and `deleteHistory`

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6871ee980dcc83239c71a0ce65a834be