### PR TITLE
Enable ranking PDF export

### DIFF
--- a/web/components/ExportButtons.tsx
+++ b/web/components/ExportButtons.tsx
@@ -28,15 +28,38 @@ export default function ExportButtons({ data }: Props) {
     URL.revokeObjectURL(url);
   };
 
-  const exportPdf = () => {
-    alert(`${t('comingSoon')}: PDF`);
+  const exportPdf = async () => {
+    const jsPDFModule = await import('jspdf');
+    const doc = new jsPDFModule.jsPDF();
+    doc.setFontSize(16);
+    doc.text(t('title'), 10, 10);
+    doc.setFontSize(12);
+    let y = 20;
+    data.forEach((r) => {
+      const header = `${r.rank}. ${r.name} (${r.score})`;
+      doc.text(header, 10, y);
+      y += 7;
+      const reasons = Object.entries(r.reasons ?? {})
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('; ');
+      if (reasons) {
+        const lines = doc.splitTextToSize(reasons, 180);
+        doc.text(lines, 10, y);
+        y += lines.length * 7;
+      }
+      y += 5;
+      if (y > 280) {
+        doc.addPage();
+        y = 10;
+      }
+    });
+    doc.save('ranking.pdf');
   };
   return (
     <div className="buttons">
       <button
-        className="btn btn-primary btn-disabled"
+        className="btn btn-primary"
         onClick={exportPdf}
-        disabled
       >
         {t('exportPdf')}
       </button>

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,8 @@
     "react-dom": "18.2.0",
     "lucide-react": "^0.379.0",
     "chart.js": "^4.4.1",
-    "react-chartjs-2": "^5.2.0"
+    "react-chartjs-2": "^5.2.0",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@types/node": "22.15.30",


### PR DESCRIPTION
## Summary
- add `jspdf` to support generating ranking results PDF
- implement PDF export feature and enable the PDF button

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871eea83cf48323a77da6e6ba9841c7