### PR TITLE
Configure CORS via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ The API requires `OPENAI_API_KEY` to be set in the environment. Copy
 before running the server. When testing without a key, set
 `USE_DUMMY_DATA=1` to return sample rankings.
 
+When deploying the backend, set the `ALLOWED_ORIGINS` environment variable to
+the URL of your frontend (comma‑separated if multiple). This controls which
+sites are allowed to make requests to the API. By default it only allows
+`http://localhost:3000` for local development.
+
 If you don't have an OpenAI API key handy, start the server with
 ``USE_DUMMY_DATA=1`` to use built-in sample rankings:
 

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -7,15 +7,22 @@ import json
 from pathlib import Path
 from uuid import uuid4
 import logging
+import os
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
+allowed_origins = [
+    origin.strip()
+    for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+    if origin.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- make FastAPI CORS origins configurable through `ALLOWED_ORIGINS`
- document setting `ALLOWED_ORIGINS` when deploying

## Testing
- `python -m py_compile server/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6871eea436d4832389058ed6874044bf