### PR TITLE
Add env-based CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The API requires `OPENAI_API_KEY` to be set in the environment. Copy
 before running the server. When testing without a key, set
 `USE_DUMMY_DATA=1` to return sample rankings.
 
-When deploying the backend, set the `ALLOWED_ORIGINS` environment variable to
+When deploying the backend, set the `FRONTEND_ORIGINS` environment variable to
 the URL of your frontend (comma‑separated if multiple). This controls which
 sites are allowed to make requests to the API. By default it only allows
 `http://localhost:3000` for local development.

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -14,11 +14,8 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
-allowed_origins = [
-    origin.strip()
-    for origin in os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
-    if origin.strip()
-]
+frontend_origins_env = os.getenv("FRONTEND_ORIGINS", "http://localhost:3000")
+allowed_origins = [origin.strip() for origin in frontend_origins_env.split(",") if origin.strip()]
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
- configure CORS using `FRONTEND_ORIGINS` environment variable
- update README instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68728b1f184483238b0504b5ee1533c6