### PR TITLE
Add focus ring styles on input fields

### DIFF
--- a/web/components/CandidateInputs.tsx
+++ b/web/components/CandidateInputs.tsx
@@ -24,7 +24,7 @@ export default function CandidateInputs({ candidates, setCandidates }: Props) {
       {candidates.map((c, i) => (
         <div key={i} className="flex items-center gap-2">
           <input
-            className="flex-1 p-2 border rounded-md bg-gray-50"
+            className="flex-1 p-2 border rounded-md bg-gray-50 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary"
             placeholder={t('itemPlaceholder')}
             value={c}
             onChange={(e) => update(e.target.value, i)}

--- a/web/components/CriteriaInputs.tsx
+++ b/web/components/CriteriaInputs.tsx
@@ -28,7 +28,7 @@ export default function CriteriaInputs({ criteria, setCriteria }: Props) {
       {criteria.map((c, i) => (
         <div key={i} className="flex items-center gap-2">
           <input
-            className="flex-1 p-2 border rounded-md bg-gray-50"
+            className="flex-1 p-2 border rounded-md bg-gray-50 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary"
             placeholder={t('criterionPlaceholder')}
             value={c.name}
             onChange={(e) => update(i, 'name', e.target.value)}

--- a/web/globals.css
+++ b/web/globals.css
@@ -8,6 +8,9 @@
   body {
     @apply p-4 font-sans bg-background text-[16px];
   }
+  input:focus {
+    @apply outline-none ring-2 ring-primary border-primary;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- highlight input focus state with Tailwind classes
- globally style input focus ring color

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68728b2113dc8323ab127308ab195187