### PR TITLE
Enhance range input style

### DIFF
--- a/web/components/CriteriaInputs.tsx
+++ b/web/components/CriteriaInputs.tsx
@@ -36,6 +36,7 @@ export default function CriteriaInputs({ criteria, setCriteria }: Props) {
           <div className="flex items-center gap-2">
             <input
               type="range"
+              className="range-input"
               min={1}
               max={5}
               step={1}

--- a/web/globals.css
+++ b/web/globals.css
@@ -29,5 +29,23 @@
   .buttons {
     @apply mt-5 flex gap-2;
   }
+
+  /* Custom range input styling */
+  .range-input {
+    @apply w-40 h-2 rounded-lg bg-gray-200 cursor-pointer appearance-none;
+  }
+  .range-input::-webkit-slider-thumb {
+    @apply w-5 h-5 rounded-full bg-primary appearance-none;
+    margin-top: -6px;
+  }
+  .range-input::-moz-range-thumb {
+    @apply w-5 h-5 rounded-full bg-primary border-none;
+  }
+  .range-input::-webkit-slider-runnable-track {
+    @apply bg-primary/30 h-2 rounded-lg;
+  }
+  .range-input::-moz-range-track {
+    @apply bg-primary/30 h-2 rounded-lg;
+  }
 }
 


### PR DESCRIPTION
## Summary
- add custom slider styles in `globals.css`
- use new `.range-input` class in criteria form

## Testing
- `USE_DUMMY_DATA=1 pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68728b2231208323966ef4975b8fd18f