### PR TITLE
Add orange accent color and update buttons

### DIFF
--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -22,7 +22,7 @@ export default function SaveHistoryButton({ data }: { data: any }) {
 
   return (
     <button
-      className="btn btn-accent"
+      className="btn btn-accent2"
       onClick={handleSave}
     >
       {t('saveHistory')}

--- a/web/globals.css
+++ b/web/globals.css
@@ -20,6 +20,9 @@
   .btn-accent {
     @apply bg-accent hover:bg-accent-dark;
   }
+  .btn-accent2 {
+    @apply bg-accent2 hover:bg-accent2-dark;
+  }
   .btn-disabled {
     @apply cursor-not-allowed opacity-60;
   }

--- a/web/pages/create.tsx
+++ b/web/pages/create.tsx
@@ -122,7 +122,7 @@ export default function Create() {
       <button
         onClick={handleSubmit}
         disabled={loading}
-        className="w-full py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition disabled:opacity-50 flex items-center justify-center gap-2"
+        className="w-full py-2 bg-accent2 text-white rounded-md shadow hover:bg-accent2-dark transition disabled:opacity-50 flex items-center justify-center gap-2"
       >
         {loading && <Spinner />}
         {loading ? t('generating') : t('generate')}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -14,6 +14,10 @@ module.exports = {
           DEFAULT: '#10b981',
           dark: '#059669'
         },
+        accent2: {
+          DEFAULT: '#F5A623',
+          dark: '#d97706'
+        },
         background: '#f9fafb'
       },
       spacing: {


### PR DESCRIPTION
## Summary
- extend Tailwind theme with secondary accent color
- add `.btn-accent2` style
- use new accent color for the save history and generate buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68728b230aa483239d954761ea4fd300