### PR TITLE
Add share image endpoint and client

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import Body, FastAPI, HTTPException
+from fastapi import Body, FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from .services.ranker import RankerService
@@ -8,6 +8,8 @@ from pathlib import Path
 from uuid import uuid4
 import logging
 import os
+from io import BytesIO
+from PIL import Image, ImageDraw, ImageFont
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -116,3 +118,23 @@ async def delete_history(item_id: str):
         raise HTTPException(status_code=404, detail="Item not found")
     _write_history(new_items)
     return {"status": "deleted"}
+
+
+@app.post("/share_image")
+async def share_image(data: List[Any] = Body(...)):
+    """Return a simple PNG image showing ranking data."""
+    font = ImageFont.load_default()
+    line_height = 20
+    padding = 10
+    lines = [f"{item.get('rank')}. {item.get('name')} ({item.get('score')})" for item in data]
+    width = max((ImageDraw.Draw(Image.new("RGB", (1, 1))).textlength(line, font=font) for line in lines), default=100) + padding * 2
+    height = line_height * len(lines) + padding * 2
+    img = Image.new("RGB", (int(width), height), "white")
+    draw = ImageDraw.Draw(img)
+    y = padding
+    for line in lines:
+        draw.text((padding, y), line, fill="black", font=font)
+        y += line_height
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return Response(buf.getvalue(), media_type="image/png")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.111.0
 uvicorn==0.29.0
 openai==1.9.0
 httpx>=0.23.0
+pillow==10.3.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,3 +49,10 @@ def test_history_crud(tmp_path, monkeypatch):
     resp = client.get("/history")
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+def test_share_image_endpoint():
+    payload = [{"rank": 1, "name": "A", "score": 10}, {"rank": 2, "name": "B", "score": 9}]
+    resp = client.post("/share_image", json=payload)
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/")

--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -6,15 +6,25 @@ export default function ShareButton({ data }: { data: any }) {
   const handleShare = async () => {
     try {
       const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-      const res = await fetch(`${apiUrl}/history`, {
+      const res = await fetch(`${apiUrl}/share_image`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
-      const saved = await res.json();
-      const url = `${window.location.origin}/results?id=${saved.id}`;
-      await navigator.clipboard.writeText(url);
-      alert(`URL copied: ${url}`);
+      if (!res.ok) throw new Error('failed');
+      const blob = await res.blob();
+      const file = new File([blob], 'ranking.png', { type: 'image/png' });
+      const shareApi = navigator as any;
+      if (shareApi.share && shareApi.canShare?.({ files: [file] })) {
+        await shareApi.share({ files: [file], title: 'ranking' });
+      } else {
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = 'ranking.png';
+        link.click();
+        URL.revokeObjectURL(url);
+      }
     } catch (e) {
       alert('Share failed');
     }


### PR DESCRIPTION
## Summary
- add `/share_image` endpoint in FastAPI
- enable basic image generation using Pillow
- add `pillow` to server requirements
- add test for `/share_image`
- update ShareButton component to download/share the image

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68728b23b0588323b18ba11934d5a7bd