### PR TITLE
Add public history timeline

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,3 +49,16 @@ def test_history_crud(tmp_path, monkeypatch):
     resp = client.get("/history")
     assert resp.status_code == 200
     assert resp.json() == []
+
+def test_public_history(tmp_path, monkeypatch):
+    temp_history = tmp_path / "history.json"
+    monkeypatch.setattr(main, "HISTORY_FILE", temp_history)
+
+    client.post("/history", json={"data": {"foo": "public"}, "public": True})
+    client.post("/history", json={"foo": "private"})
+
+    resp = client.get("/public")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["data"] == {"foo": "public"}

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -1,7 +1,9 @@
 import { useTranslations } from 'next-intl';
+import { useState } from 'react';
 
 export default function SaveHistoryButton({ data }: { data: any }) {
   const t = useTranslations();
+  const [isPublic, setIsPublic] = useState(false);
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
@@ -12,7 +14,7 @@ export default function SaveHistoryButton({ data }: { data: any }) {
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(data)
+        body: JSON.stringify({ data, public: isPublic })
       });
       alert(t('saved'));
     } catch (err) {
@@ -21,12 +23,19 @@ export default function SaveHistoryButton({ data }: { data: any }) {
   };
 
   return (
-    <button
-      className="btn btn-accent"
-      onClick={handleSave}
-    >
-      {t('saveHistory')}
-    </button>
+    <div className="flex items-center gap-2">
+      <label className="flex items-center gap-1 text-sm">
+        <input
+          type="checkbox"
+          checked={isPublic}
+          onChange={(e) => setIsPublic(e.target.checked)}
+        />
+        {t('publicLabel')}
+      </label>
+      <button className="btn btn-accent" onClick={handleSave}>
+        {t('saveHistory')}
+      </button>
+    </div>
   );
 }
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -34,5 +34,8 @@
   "visualAnalysis": "Visual Analysis",
   "share": "Share",
   "historyTitle": "History",
-  "deleteHistory": "Delete"
+  "deleteHistory": "Delete",
+  "publicLabel": "Public",
+  "timelineTitle": "Public Timeline",
+  "view": "View"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -34,5 +34,8 @@
   "visualAnalysis": "ビジュアル分析",
   "share": "共有",
   "historyTitle": "履歴",
-  "deleteHistory": "削除"
+  "deleteHistory": "削除",
+  "publicLabel": "公開",
+  "timelineTitle": "公開タイムライン",
+  "view": "見る"
 }

--- a/web/pages/timeline.tsx
+++ b/web/pages/timeline.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { RankingItem } from '../types';
+
+interface HistoryEntry {
+  id: string;
+  data: RankingItem[];
+  public?: boolean;
+}
+
+export default function TimelinePage() {
+  const t = useTranslations();
+  const [items, setItems] = useState<HistoryEntry[]>([]);
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`${apiUrl}/public`);
+        if (res.ok) {
+          const data = await res.json();
+          setItems(data);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    load();
+  }, [apiUrl]);
+
+  return (
+    <div className="max-w-[1100px] mx-auto px-4 space-y-4">
+      <h1 className="text-3xl font-bold">{t('timelineTitle')}</h1>
+      {items.length === 0 ? (
+        <p>{t('noResults')}</p>
+      ) : (
+        <div className="space-y-4">
+          {items.map((item) => (
+            <div key={item.id} className="bg-white p-4 rounded shadow">
+              <h2 className="font-semibold mb-1">
+                {item.data && item.data[0]?.name ? item.data[0].name : item.id}
+              </h2>
+              <p className="text-sm mb-2 truncate">
+                {Array.isArray(item.data)
+                  ? item.data.map((r) => r.name).join(', ')
+                  : ''}
+              </p>
+              <Link
+                href={`/results?id=${item.id}`}
+                className="text-blue-600 hover:underline"
+              >
+                {t('view')}
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support posting and filtering public history entries on the API
- expose `/public` API route
- show a checkbox in **SaveHistoryButton** for marking public entries
- add translations and a new timeline page that lists public rankings
- test the new `/public` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68728b2558ec8323a36c0f53c389655b