### PR TITLE
Add share copy messages

### DIFF
--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -14,9 +14,9 @@ export default function ShareButton({ data }: { data: any }) {
       const saved = await res.json();
       const url = `${window.location.origin}/results?id=${saved.id}`;
       await navigator.clipboard.writeText(url);
-      alert(`URL copied: ${url}`);
+      alert(t('shareCopied', { url }));
     } catch (e) {
-      alert('Share failed');
+      alert(t('shareFailed'));
     }
   };
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -34,5 +34,7 @@
   "visualAnalysis": "Visual Analysis",
   "share": "Share",
   "historyTitle": "History",
-  "deleteHistory": "Delete"
+  "deleteHistory": "Delete",
+  "shareCopied": "URL copied: {url}",
+  "shareFailed": "Share failed"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -34,5 +34,7 @@
   "visualAnalysis": "ビジュアル分析",
   "share": "共有",
   "historyTitle": "履歴",
-  "deleteHistory": "削除"
+  "deleteHistory": "削除",
+  "shareCopied": "URLをコピーしました: {url}",
+  "shareFailed": "共有に失敗しました"
 }


### PR DESCRIPTION
## Summary
- add `shareCopied` and `shareFailed` strings in English and Japanese
- use translated messages in `ShareButton`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68728b3849bc83238c43200529ecd17a