### PR TITLE
Implement base theme

### DIFF
--- a/web/globals.css
+++ b/web/globals.css
@@ -2,11 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap');
 
 @layer base {
   body {
-    @apply p-4 font-sans bg-background text-[16px];
+    @apply p-4 font-sans bg-background text-[16px] text-textPrimary;
   }
   input:focus {
     @apply outline-none ring-2 ring-primary border-primary;
@@ -18,19 +19,19 @@
     @apply px-3 py-1 rounded text-white transition font-medium;
   }
   .btn-primary {
-    @apply bg-primary hover:bg-primary-dark;
+    @apply bg-primary hover:bg-primary-dark transform hover:scale-105;
   }
   .btn-accent {
     @apply bg-accent hover:bg-accent-dark;
   }
   .btn-accent2 {
-    @apply bg-accent2 hover:bg-accent2-dark;
+    @apply bg-accent hover:bg-accent-dark;
   }
   .btn-disabled {
     @apply cursor-not-allowed opacity-60;
   }
   .card {
-    @apply bg-white p-4 rounded-lg shadow;
+    @apply bg-surface p-6 rounded-xl shadow-md;
   }
   .buttons {
     @apply mt-5 flex gap-2;
@@ -41,11 +42,11 @@
     @apply w-40 h-2 rounded-lg bg-gray-200 cursor-pointer appearance-none;
   }
   .range-input::-webkit-slider-thumb {
-    @apply w-5 h-5 rounded-full bg-primary appearance-none;
-    margin-top: -6px;
+    @apply w-6 h-6 rounded-full bg-primary appearance-none;
+    margin-top: -8px;
   }
   .range-input::-moz-range-thumb {
-    @apply w-5 h-5 rounded-full bg-primary border-none;
+    @apply w-6 h-6 rounded-full bg-primary border-none;
   }
   .range-input::-webkit-slider-runnable-track {
     @apply bg-primary/30 h-2 rounded-lg;

--- a/web/pages/create.tsx
+++ b/web/pages/create.tsx
@@ -96,7 +96,7 @@ export default function Create() {
   };
 
   return (
-    <div className="max-w-[1280px] mx-auto px-4">
+    <div className="max-w-[1140px] mx-auto px-4">
       <div className="max-w-xl mx-auto mt-10 space-y-6">
         <LanguageSwitcher />
         <h1 className="text-3xl font-bold text-center">{t('generate')}</h1>

--- a/web/pages/history.tsx
+++ b/web/pages/history.tsx
@@ -38,7 +38,7 @@ export default function HistoryPage() {
   }, []);
 
   return (
-    <div className="max-w-[1100px] mx-auto px-4 space-y-4">
+    <div className="max-w-[1140px] mx-auto px-4 space-y-4">
       <h1 className="text-3xl font-bold">{t('historyTitle')}</h1>
       {items.length === 0 ? (
         <p>{t('noResults')}</p>

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="max-w-[1100px] mx-auto px-4 text-center space-y-20">
+    <div className="max-w-[1140px] mx-auto px-4 text-center space-y-20">
       <section className="space-y-6 pt-20">
         <h1 className="text-5xl font-bold">あらゆる『迷い』に、明確な答えを。</h1>
         <p className="text-lg">複数の選択肢を、あなただけの評価基準で簡単にランキング。直感的なビジュアル分析で、最適な選択をサポートします。</p>

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -97,7 +97,7 @@ export default function Results() {
   };
 
   return (
-    <div className="max-w-[1100px] mx-auto px-4 text-base">
+    <div className="max-w-[1140px] mx-auto px-4 text-base">
       <div className="space-y-4">
         <LanguageSwitcher />
       <h1 className="text-3xl font-bold text-center">{t('title')}</h1>

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -7,25 +7,25 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          DEFAULT: '#3b82f6',
-          dark: '#2563eb'
+          DEFAULT: '#4A90E2',
+          dark: '#3076c7'
         },
         accent: {
-          DEFAULT: '#10b981',
-          dark: '#059669'
-        },
-        accent2: {
           DEFAULT: '#F5A623',
-          dark: '#d97706'
+          dark: '#d9880e'
         },
-        background: '#f9fafb'
+        background: '#F8F9FA',
+        surface: '#FFFFFF',
+        textPrimary: '#212529',
+        textSecondary: '#6C757D',
+        border: '#DEE2E6'
       },
       spacing: {
         section: '1.5rem',
         page: '2rem'
       },
       fontFamily: {
-        sans: ['\'Noto Sans JP\'', 'sans-serif']
+        sans: ['Inter', '\'Noto Sans JP\'', 'sans-serif']
       },
       keyframes: {
         fadeIn: { '0%': { opacity: 0 }, '100%': { opacity: 1 } }


### PR DESCRIPTION
## Summary
- update Tailwind palette to new primary/accent colors and fonts
- tweak global styles with Inter font, scaled buttons, redesigned cards and sliders
- adjust container widths to 1140px

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6872995ffc088323a1ec370e583812cf