### PR TITLE
Update env usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_FIREBASE_API_KEY=your_key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The API requires `OPENAI_API_KEY` to be set in the environment. Copy
 before running the server. When testing without a key, set
 `USE_DUMMY_DATA=1` to return sample rankings.
 
+Google authentication uses the environment variables `GOOGLE_CLIENT_ID` and
+`GOOGLE_CLIENT_SECRET`. Set these in your `.env` file along with the Firebase
+credentials.
+
 The web frontend uses Firebase Authentication and Firestore. Set the
 `NEXT_PUBLIC_FIREBASE_*` variables in your `.env` file with your Firebase
 project credentials.

--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -25,12 +25,11 @@ class RankerService:
         """
         self.use_dummy = os.getenv("USE_DUMMY_DATA") == "1"
 
-        # openai v1.x automatically reads settings such as ``OPENAI_API_KEY``
-        # from environment variables.  Passing unsupported arguments like
-        # ``proxies`` or ``api_key`` will raise ``TypeError`` in recent
-        # versions, so we simply instantiate ``OpenAI()`` when not in dummy
-        # mode.
-        self.client = None if self.use_dummy else OpenAI()
+        # Explicitly read the API key from the environment instead of relying
+        # on ``openai``'s implicit loading. This makes it clear which variable
+        # is required and avoids surprises when the library behaviour changes.
+        api_key = os.getenv("OPENAI_API_KEY")
+        self.client = None if self.use_dummy else OpenAI(api_key=api_key)
 
     def _cleanup_json(self, text: str) -> str:
         """Try to extract a JSON object or array from a text blob."""


### PR DESCRIPTION
## Summary
- load `OPENAI_API_KEY` explicitly in the Python ranker
- document Google auth secrets
- extend `.env.example` with Google auth variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68738322a88c8323b0dd01a52d7ba884