### PR TITLE
Use env vars for auth and OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_FIREBASE_API_KEY=your_key
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com

--- a/server/app/services/ranker.py
+++ b/server/app/services/ranker.py
@@ -25,12 +25,11 @@ class RankerService:
         """
         self.use_dummy = os.getenv("USE_DUMMY_DATA") == "1"
 
-        # openai v1.x automatically reads settings such as ``OPENAI_API_KEY``
-        # from environment variables.  Passing unsupported arguments like
-        # ``proxies`` or ``api_key`` will raise ``TypeError`` in recent
-        # versions, so we simply instantiate ``OpenAI()`` when not in dummy
-        # mode.
-        self.client = None if self.use_dummy else OpenAI()
+        # Initialize the OpenAI client using the API key from the environment
+        # explicitly.  This makes it clear which setting is used and keeps
+        # credentials out of the code base.
+        api_key = os.environ.get("OPENAI_API_KEY")
+        self.client = None if self.use_dummy else OpenAI(api_key=api_key)
 
     def _cleanup_json(self, text: str) -> str:
         """Try to extract a JSON object or array from a text blob."""

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
     "chart.js": "^4.4.1",
     "react-chartjs-2": "^5.2.0",
     "jspdf": "^2.5.1",
-    "firebase": "^9.23.0"
+    "firebase": "^9.23.0",
+    "next-auth": "^4.24.7"
   },
   "devDependencies": {
     "@types/node": "22.15.30",

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,13 @@
+import NextAuth from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+
+export const authOptions = {
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+  ],
+};
+
+export default NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- expand `.env.example` with Google and OpenAI settings
- initialize OpenAI client with `OPENAI_API_KEY`
- add `next-auth` dependency and implement Google auth API route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68738322a88c8323b0dd01a52d7ba884