### PR TITLE
Improve Firebase env var setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Copy this file to `.env` for the server and to `web/.env.local` for the Next.js
+# frontend. Replace the placeholder values with your actual API keys.
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret

--- a/web/firebase.ts
+++ b/web/firebase.ts
@@ -11,6 +11,13 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
+// Provide a helpful error if the environment variables are missing.
+if (!firebaseConfig.apiKey) {
+  throw new Error(
+    'Missing Firebase env vars. Did you copy .env.example to web/.env.local?'
+  );
+}
+
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const provider = new GoogleAuthProvider();


### PR DESCRIPTION
## Summary
- fail fast when Firebase env vars are missing
- clarify in `.env.example` where to place environment files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6873dc36be4083239d00d11343ac49e6