### PR TITLE
Fix Firebase env files and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 # Misc
 .DS_Store
 server/app/history.json
+web/.env.local

--- a/README.md
+++ b/README.md
@@ -30,13 +30,7 @@ The API requires `OPENAI_API_KEY` to be set in the environment. Copy
 before running the server. When testing without a key, set
 `USE_DUMMY_DATA=1` to return sample rankings.
 
-The web frontend uses Firebase Authentication and Firestore. Set the
-`NEXT_PUBLIC_FIREBASE_*` variables in your `.env` file with your Firebase
-project credentials. When running `npm run dev` inside the `web` directory,
-Next.js only reads environment files from that folder. Copy `.env.example` to
-`web/.env.local` (or `web/.env`) and fill in your Firebase keys there;
-otherwise the frontend will start with an invalid API key and Firebase will
-raise `auth/invalid-api-key` errors.
+The web frontend uses Firebase Authentication and Firestore. Set the `NEXT_PUBLIC_FIREBASE_*` variables with your Firebase project credentials. When running `npm run dev` inside the `web` directory, Next.js only reads environment files from that folder. Copy `web/.env.local.example` to `web/.env.local` (or `web/.env`) and fill in your Firebase keys there; otherwise the frontend will start with an invalid API key and Firebase will raise `auth/invalid-api-key` errors.
 
 When deploying the backend, set the `FRONTEND_ORIGINS` environment variable to
 the URL of your frontend (comma‑separated if multiple). This controls which

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,3 +1,5 @@
+# Copy this file to .env.local and replace with your keys
+# Example environment variables for Firebase auth
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 NEXT_PUBLIC_API_URL=http://localhost:8000

--- a/web/firebase.ts
+++ b/web/firebase.ts
@@ -11,10 +11,23 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Provide a helpful error if the environment variables are missing.
-if (!firebaseConfig.apiKey) {
+// Provide a helpful error if any required environment variables are missing or
+// left as placeholders.
+const missingVars = [
+  'apiKey',
+  'authDomain',
+  'projectId',
+  'storageBucket',
+  'messagingSenderId',
+  'appId',
+].filter((key) => {
+  const value = (firebaseConfig as Record<string, string | undefined>)[key];
+  return !value || value.includes('your_');
+});
+
+if (missingVars.length > 0) {
   throw new Error(
-    'Missing Firebase env vars. Did you copy .env.example to web/.env.local?'
+    'Missing Firebase env vars. Did you copy web/.env.local.example to web/.env.local and set the values?'
   );
 }
 


### PR DESCRIPTION
## Summary
- stop tracking `web/.env.local`
- provide `web/.env.local.example`
- document new env setup in README
- validate all Firebase env vars

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6873fc9d0e348323a006bc83f8d3371a