### PR TITLE
Fix sample env files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,12 @@
 # Copy this file to `.env` for the server and to `web/.env.local` for the Next.js
 # frontend. Replace the placeholder values with your actual API keys.
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
-GOOGLE_CLIENT_ID=your_google_client_id
-GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_ID=dummy_google_client_id
+GOOGLE_CLIENT_SECRET=dummy_google_client_secret
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_FIREBASE_API_KEY=your_key
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
-NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+NEXT_PUBLIC_FIREBASE_API_KEY=dummy_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=dummy_project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=dummy_project
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1234567890
 NEXT_PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abcdef

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,11 +1,11 @@
 # Copy this file to .env.local and replace with your keys
 # Example environment variables for Firebase auth
-GOOGLE_CLIENT_ID=your_google_client_id
-GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_ID=dummy_google_client_id
+GOOGLE_CLIENT_SECRET=dummy_google_client_secret
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_FIREBASE_API_KEY=your_key
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
-NEXT_PUBLIC_FIREBASE_PROJECT_ID=your_project
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
+NEXT_PUBLIC_FIREBASE_API_KEY=dummy_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=dummy_project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=dummy_project
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1234567890
 NEXT_PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abcdef


### PR DESCRIPTION
## Summary
- update example env files with dummy credentials for smoother local setup

## Testing
- `pytest -q tests/test_api.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6874037841748323a074a4ab5d166686