### PR TITLE
Add default web env file

### DIFF
--- a/web/.env.local
+++ b/web/.env.local
@@ -1,0 +1,11 @@
+# Copy this file to .env.local and replace with your keys
+# Example environment variables for Firebase auth
+GOOGLE_CLIENT_ID=dummy_google_client_id
+GOOGLE_CLIENT_SECRET=dummy_google_client_secret
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_FIREBASE_API_KEY=dummy_api_key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=dummy_project.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=dummy_project
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1234567890
+NEXT_PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abcdef


### PR DESCRIPTION
## Summary
- add example values in `web/.env.local` so the frontend can boot without extra setup

## Testing
- `pytest -q` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68748bb60b5c8323bc406087354feda0