### PR TITLE
Allow running web without Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The API requires `OPENAI_API_KEY` to be set in the environment. Copy
 before running the server. When testing without a key, set
 `USE_DUMMY_DATA=1` to return sample rankings.
 
-The web frontend uses Firebase Authentication and Firestore. Set the `NEXT_PUBLIC_FIREBASE_*` variables with your Firebase project credentials. When running `npm run dev` inside the `web` directory, Next.js only reads environment files from that folder. Copy `web/.env.local.example` to `web/.env.local` (or `web/.env`) and fill in your Firebase keys there; otherwise the frontend will start with an invalid API key and Firebase will raise `auth/invalid-api-key` errors.
+The web frontend uses Firebase Authentication and Firestore. Set the `NEXT_PUBLIC_FIREBASE_*` variables with your Firebase project credentials. When running `npm run dev` inside the `web` directory, Next.js only reads environment files from that folder. Copy `web/.env.local.example` to `web/.env.local` (or `web/.env`) and fill in your Firebase keys there; otherwise the frontend will start with an invalid API key and Firebase will raise `auth/invalid-api-key` errors. If these variables are omitted the app will still run, but login functionality will be disabled.
 
 When deploying the backend, set the `FRONTEND_ORIGINS` environment variable to
 the URL of your frontend (comma‑separated if multiple). This controls which

--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { onAuthStateChanged, signInWithPopup, signOut, User } from 'firebase/auth';
-import { auth, provider } from '../firebase';
+import { auth, provider, firebaseEnabled } from '../firebase';
 
 interface AuthContextType {
   user: User | null;
@@ -20,16 +20,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
-    const unsub = onAuthStateChanged(auth, (u) => setUser(u));
+    if (!firebaseEnabled) return;
+    const unsub = onAuthStateChanged(auth!, (u) => setUser(u));
     return () => unsub();
   }, []);
 
   const login = async () => {
-    await signInWithPopup(auth, provider);
+    if (!firebaseEnabled) {
+      alert('Login is disabled');
+      return;
+    }
+    await signInWithPopup(auth!, provider!);
   };
 
   const logout = async () => {
-    await signOut(auth);
+    if (!firebaseEnabled) return;
+    await signOut(auth!);
   };
 
   return (

--- a/web/firebase.ts
+++ b/web/firebase.ts
@@ -11,8 +11,8 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-// Provide a helpful error if any required environment variables are missing or
-// left as placeholders.
+// Firebase can be disabled by omitting the environment variables.  In that case
+// authentication and Firestore features will be skipped.
 const missingVars = [
   'apiKey',
   'authDomain',
@@ -29,13 +29,20 @@ const missingVars = [
   );
 });
 
-if (missingVars.length > 0) {
-  throw new Error(
-    'Missing Firebase env vars. Did you copy web/.env.local.example to web/.env.local and set the values?'
-  );
+export const firebaseEnabled = missingVars.length === 0;
+
+let app;
+let auth;
+let provider;
+let db;
+
+if (firebaseEnabled) {
+  app = initializeApp(firebaseConfig);
+  auth = getAuth(app);
+  provider = new GoogleAuthProvider();
+  db = getFirestore(app);
+} else {
+  console.warn('Firebase disabled: missing env vars');
 }
 
-const app = initializeApp(firebaseConfig);
-export const auth = getAuth(app);
-export const provider = new GoogleAuthProvider();
-export const db = getFirestore(app);
+export { auth, provider, db };


### PR DESCRIPTION
## Summary
- support disabling Firebase by skipping initialization when env vars are absent
- adjust AuthProvider to handle disabled Firebase
- document Firebase optionality in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687658a5f7ec8323ab9c1cccb332e757