### PR TITLE
Improve firebase env troubleshooting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,17 @@ npm install
 npm run dev
 ```
 Run these commands from the `web` directory so that Next.js can read the environment variables located there.
-The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the `dummy_*` values with your actual Firebase credentials before starting the dev server.
-If any of the Firebase variables are missing, the frontend logs a message like
-`Firebase disabled: missing env vars (apiKey, authDomain)`. Use this hint to
-verify that all keys are loaded correctly when troubleshooting login issues.
+The `.env.local` file is git-ignored, so copy `web/.env.local.example` to
+`web/.env.local` and replace the `dummy_*` values with your actual Firebase
+credentials before starting the dev server. If any of the Firebase variables are
+missing, the frontend logs a message like `Firebase disabled: missing env vars
+(apiKey, authDomain)`. Use this hint to verify that all keys are loaded
+correctly when troubleshooting login issues.  When this warning persists:
+
+- Confirm that `.env.local` lives in the `web` directory.
+- Ensure there are **no quotes or trailing spaces** around the values.
+- Restart `npm run dev` after editing the file so Next.js reloads the
+  environment.
 The `web` directory uses TypeScript with a standard `tsconfig.json` configured for Next.js. Run `npm run build` to
 compile the project for production or use `npx tsc --noEmit` to perform a type
 check only.

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,4 +1,5 @@
-# Copy this file to .env.local and replace with your keys
+# Copy this file to `.env.local` and replace with your keys.
+# Do not wrap values in quotes and avoid trailing spaces.
 # Example environment variables for Firebase auth
 GOOGLE_CLIENT_ID=dummy_google_client_id
 GOOGLE_CLIENT_SECRET=dummy_google_client_secret


### PR DESCRIPTION
## Summary
- clarify how to troubleshoot missing Firebase environment variables in the README
- add note in `.env.local.example` about avoiding quotes and trailing spaces

## Testing
- `npm install` in `web`
- `npx tsc --noEmit` *(fails: implicit any type for `db`)*
- `npm run build` *(fails: same TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687944e768348323a16eb9bab3d813b1