### PR TITLE
Fix server imports and prune dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -16,8 +16,7 @@
     "chart.js": "^4.4.1",
     "react-chartjs-2": "^5.2.0",
     "jspdf": "^2.5.1",
-    "firebase": "^9.23.0",
-    "next-auth": "^4.24.7"
+    "firebase": "^9.23.0"
   },
   "devDependencies": {
     "@types/node": "22.15.30",


### PR DESCRIPTION
## Summary
- add an empty `server/__init__.py` so the server package is importable
- remove the unused `next-auth` package from `web/package.json`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847ff958b08323ad4fd17324306980