### PR TITLE
Improve export/share features and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ GET    /history        # list all history entries
 DELETE /history/{id}   # remove an entry by its ID
 ```
 
+### Testing
+
+Run the backend tests with `pytest`. The repository includes a `pytest.ini`
+file so that imports resolve automatically. If you prefer not to rely on the
+config file, prefix the command with `PYTHONPATH=.`:
+
+```bash
+PYTHONPATH=. pytest -q
+```
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/web/components/CriteriaRadar.tsx
+++ b/web/components/CriteriaRadar.tsx
@@ -23,9 +23,10 @@ ChartJS.register(
 interface Props {
   results: RankingItem[];
   full?: boolean;
+  id?: string;
 }
 
-const CriteriaRadar: FC<Props> = ({ results, full }) => {
+const CriteriaRadar: FC<Props> = ({ results, full, id }) => {
   if (!results || results.length === 0) return null;
   const criteria = Object.keys(results[0].reasons ?? {});
   if (criteria.length === 0) return <p>No criteria data</p>;
@@ -47,7 +48,7 @@ const CriteriaRadar: FC<Props> = ({ results, full }) => {
   const data = { labels: criteria, datasets };
 
   return (
-    <div className={full ? 'max-w-full mx-auto' : 'max-w-md mx-auto'}>
+    <div id={id} className={full ? 'max-w-full mx-auto' : 'max-w-md mx-auto'}>
       <Radar data={data} />
     </div>
   );

--- a/web/components/ExportButtons.tsx
+++ b/web/components/ExportButtons.tsx
@@ -30,6 +30,7 @@ export default function ExportButtons({ data }: Props) {
 
   const exportPdf = async () => {
     const jsPDFModule = await import('jspdf');
+    const html2canvas = (await import('html2canvas')).default;
     const doc = new jsPDFModule.jsPDF();
     doc.setFontSize(16);
     doc.text(t('title'), 10, 10);
@@ -53,6 +54,23 @@ export default function ExportButtons({ data }: Props) {
         y = 10;
       }
     });
+    const scoreEl = document.getElementById('score-chart');
+    const radarEl = document.getElementById('criteria-radar');
+    if (scoreEl || radarEl) {
+      doc.addPage();
+      let imgY = 10;
+      if (scoreEl) {
+        const canvas = await html2canvas(scoreEl as HTMLElement);
+        const img = canvas.toDataURL('image/png');
+        doc.addImage(img, 'PNG', 10, imgY, 180, 100);
+        imgY += 110;
+      }
+      if (radarEl) {
+        const canvas = await html2canvas(radarEl as HTMLElement);
+        const img = canvas.toDataURL('image/png');
+        doc.addImage(img, 'PNG', 10, imgY, 180, 100);
+      }
+    }
     doc.save('ranking.pdf');
   };
   return (

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -27,7 +27,10 @@ export default function Header() {
             </button>
           )
         ) : (
-          <span className="text-gray-500" title="Login unavailable">
+          <span
+            className="text-gray-500"
+            title="Firebase not configured. See README for setup."
+          >
             {t('login')}
           </span>
         )}

--- a/web/components/ScoreChart.tsx
+++ b/web/components/ScoreChart.tsx
@@ -22,9 +22,10 @@ ChartJS.register(
 
 interface Props {
   results: RankingItem[];
+  id?: string;
 }
 
-const ScoreChart: FC<Props> = ({ results }) => {
+const ScoreChart: FC<Props> = ({ results, id }) => {
   if (!results || results.length === 0) return null;
 
   const data = {
@@ -41,7 +42,7 @@ const ScoreChart: FC<Props> = ({ results }) => {
   };
 
   return (
-    <div className="max-w-md mx-auto">
+    <div id={id} className="max-w-md mx-auto">
       <Radar data={data} />
     </div>
   );

--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -7,23 +7,27 @@ export default function ShareButton({ data }: { data: any }) {
   const t = useTranslations();
   const { user } = useAuth();
 
-  const handleShare = async () => {
+  const saveData = async (): Promise<string> => {
+    let savedId: string | undefined;
+    if (user) {
+      const docRef = await addDoc(collection(db, 'users', user.uid, 'rankings'), data);
+      savedId = docRef.id;
+    } else {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+      const res = await fetch(`${apiUrl}/history`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      const saved = await res.json();
+      savedId = saved.id;
+    }
+    return `${window.location.origin}/results?id=${savedId}`;
+  };
+
+  const handleCopy = async () => {
     try {
-      let savedId: string | undefined;
-      if (user) {
-        const docRef = await addDoc(collection(db, 'users', user.uid, 'rankings'), data);
-        savedId = docRef.id;
-      } else {
-        const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
-        const res = await fetch(`${apiUrl}/history`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(data),
-        });
-        const saved = await res.json();
-        savedId = saved.id;
-      }
-      const url = `${window.location.origin}/results?id=${savedId}`;
+      const url = await saveData();
       await navigator.clipboard.writeText(url);
       alert(`URL copied: ${url}`);
     } catch (e) {
@@ -31,9 +35,24 @@ export default function ShareButton({ data }: { data: any }) {
     }
   };
 
+  const handleTweet = async () => {
+    try {
+      const url = await saveData();
+      const intent = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}`;
+      window.open(intent, '_blank');
+    } catch (e) {
+      alert('Share failed');
+    }
+  };
+
   return (
-    <button className="btn btn-primary" onClick={handleShare}>
-      {t('share')}
-    </button>
+    <div className="flex gap-2">
+      <button className="btn btn-primary" onClick={handleCopy}>
+        {t('copyLink')}
+      </button>
+      <button className="btn btn-primary" onClick={handleTweet}>
+        {t('shareOnX')}
+      </button>
+    </div>
   );
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -33,6 +33,8 @@
   "tableView": "Table View",
   "visualAnalysis": "Visual Analysis",
   "share": "Share",
+  "shareOnX": "Share on X",
+  "copyLink": "Copy link",
   "historyTitle": "History",
   "deleteHistory": "Delete",
   "login": "Login with Google",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -33,6 +33,8 @@
   "tableView": "テーブル表示",
   "visualAnalysis": "ビジュアル分析",
   "share": "共有",
+  "shareOnX": "Xでシェア",
+  "copyLink": "リンクをコピー",
   "historyTitle": "履歴",
   "deleteHistory": "削除",
   "login": "Googleでログイン",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "chart.js": "^4.4.1",
     "react-chartjs-2": "^5.2.0",
     "jspdf": "^2.5.1",
+    "html2canvas": "^1.4.1",
     "firebase": "^9.23.0"
   },
   "devDependencies": {

--- a/web/pages/results.tsx
+++ b/web/pages/results.tsx
@@ -150,12 +150,12 @@ export default function Results() {
             ) : view === 'table' ? (
               <TableView results={results} />
             ) : (
-              <CriteriaRadar results={results} full />
+              <CriteriaRadar results={results} full id="criteria-radar" />
             )}
             {view !== 'analysis' && (
               <div className="mt-6">
                 <h2 className="text-xl font-semibold mb-2">{t('scoreChart')}</h2>
-                <ScoreChart results={results} />
+                <ScoreChart results={results} id="score-chart" />
               </div>
             )}
           </>


### PR DESCRIPTION
## Summary
- add testing instructions and pytest.ini
- enhance login disabled tooltip
- capture charts in exported PDF
- add X/Twitter share option with copy fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a5ad1bb083238b520c6558a686dc