### PR TITLE
Add public ranking timeline

### DIFF
--- a/server/app/main.py
+++ b/server/app/main.py
@@ -84,10 +84,20 @@ async def rank(request: RankRequest):
 async def save_history(data: Any = Body(...)):
     """Store ranking results on disk."""
     items = _read_history()
+    if isinstance(data, dict):
+        entry_data = data.get("data", data)
+        title = data.get("title")
+        is_public = bool(data.get("is_public"))
+    else:
+        entry_data = data
+        title = None
+        is_public = False
     entry = {
         "id": str(uuid4()),
-        "data": data if not isinstance(data, dict) or "data" not in data else data["data"],
+        "data": entry_data,
         "created_at": datetime.utcnow().isoformat() + "Z",
+        "title": title,
+        "is_public": is_public,
     }
     items.append(entry)
     _write_history(items)

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -11,6 +11,9 @@ export default function Header() {
         <span className="font-bold text-xl">Ranking App</span>
       </Link>
       <div className="flex items-center gap-2">
+        <Link href="/timeline">
+          <span className="text-sm underline">{t('timeline')}</span>
+        </Link>
         {firebaseEnabled ? (
           user ? (
           <>

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -11,7 +11,9 @@ export default function SaveHistoryButton({ data }: { data: any }) {
 
   const handleSave = async () => {
     try {
-      const payload = { data, created_at: new Date().toISOString() };
+      const title = prompt(t('enterTitle')) || '';
+      const isPublic = confirm(t('makePublic'));
+      const payload = { data, created_at: new Date().toISOString(), title, is_public: isPublic };
       if (user && firebaseEnabled) {
         await addDoc(collection(db, 'users', user.uid, 'rankings'), payload);
       } else {

--- a/web/firebase.ts
+++ b/web/firebase.ts
@@ -1,6 +1,6 @@
-import { initializeApp } from 'firebase/app';
-import { getAuth, GoogleAuthProvider } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { initializeApp, type FirebaseApp } from 'firebase/app';
+import { getAuth, GoogleAuthProvider, type Auth } from 'firebase/auth';
+import { getFirestore, type Firestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -31,10 +31,10 @@ const missingVars = [
 
 export const firebaseEnabled = missingVars.length === 0;
 
-let app;
-let auth;
-let provider;
-let db;
+let app: FirebaseApp | undefined;
+let auth: Auth | undefined;
+let provider: GoogleAuthProvider | undefined;
+let db: Firestore | undefined;
 
 if (firebaseEnabled) {
   app = initializeApp(firebaseConfig);

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -39,5 +39,9 @@
   "deleteHistory": "Delete",
   "login": "Login with Google",
   "logout": "Logout",
-  "profile": "Profile"
+  "profile": "Profile",
+  "enterTitle": "Enter ranking title",
+  "makePublic": "Make this ranking public?",
+  "timeline": "Public Rankings",
+  "timelineTitle": "Public Rankings"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -39,5 +39,9 @@
   "deleteHistory": "削除",
   "login": "Googleでログイン",
   "logout": "ログアウト",
-  "profile": "プロフィール"
+  "profile": "プロフィール",
+  "enterTitle": "ランキングのタイトルを入力",
+  "makePublic": "このランキングを公開しますか？",
+  "timeline": "みんなのランキング",
+  "timelineTitle": "みんなのランキング"
 }

--- a/web/pages/timeline.tsx
+++ b/web/pages/timeline.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+interface TimelineItem {
+  id: string;
+  title?: string;
+  created_at?: string;
+  is_public?: boolean;
+}
+
+export default function TimelinePage() {
+  const t = useTranslations();
+  const [items, setItems] = useState<TimelineItem[]>([]);
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch(`${apiUrl}/history`);
+        if (res.ok) {
+          const data: TimelineItem[] = await res.json();
+          setItems(data.filter((i) => i.is_public));
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="max-w-[1140px] mx-auto px-4 space-y-4">
+      <h1 className="text-3xl font-bold">{t('timelineTitle')}</h1>
+      {items.length === 0 ? (
+        <p>{t('noResults')}</p>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((item) => (
+            <li key={item.id} className="bg-white p-2 rounded shadow">
+              <Link href={`/results?id=${item.id}`}>{item.title || item.id}</Link>
+              {item.created_at && (
+                <span className="ml-2 text-xs text-gray-500">{new Date(item.created_at).toLocaleString()}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Allow saved rankings to include title and public flag
- Prompt users for title and public status when saving rankings
- Introduce timeline page showing public rankings and link from header

## Testing
- `npx tsc --noEmit`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c55e5f5b08323b99a35dc8636fecc