### PR TITLE
Support unprefixed Firebase env vars and guard Firestore usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,12 @@
 # frontend. Replace the placeholder values with your actual API keys.
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_FIREBASE_API_KEY=dummy_api_key
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=dummy_project.firebaseapp.com
-NEXT_PUBLIC_FIREBASE_PROJECT_ID=dummy_project
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
-NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1234567890
-NEXT_PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abcdef
+# Firebase credentials.  Either the FIREBASE_* or NEXT_PUBLIC_FIREBASE_* forms
+# may be used.  The build system maps the former to the latter so the values are
+# available in the browser bundle.
+FIREBASE_API_KEY=dummy_api_key
+FIREBASE_AUTH_DOMAIN=dummy_project.firebaseapp.com
+FIREBASE_PROJECT_ID=dummy_project
+FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
+FIREBASE_MESSAGING_SENDER_ID=1234567890
+FIREBASE_APP_ID=1:1234567890:web:abcdef

--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ The API requires `OPENAI_API_KEY` to be set in the environment. Copy
 before running the server. When testing without a key, set
 `USE_DUMMY_DATA=1` to return sample rankings.
 
-The web frontend uses Firebase Authentication and Firestore. Set the `NEXT_PUBLIC_FIREBASE_*` variables with your Firebase project credentials. When running `npm run dev` inside the `web` directory, Next.js only reads environment files from that folder. Copy `web/.env.local.example` to `web/.env.local` (or `web/.env`) and fill in your Firebase keys there; otherwise the frontend will start with an invalid API key and Firebase will raise `auth/invalid-api-key` errors. If these variables are omitted the app will still run, but login functionality will be disabled.
+The web frontend uses Firebase Authentication and Firestore. Set the Firebase
+credentials in your environment as either `FIREBASE_*` or
+`NEXT_PUBLIC_FIREBASE_*` variables. The Next.js configuration copies the former
+into the latter so the keys are available in the browser. When running
+`npm run dev` inside the `web` directory, Next.js only reads environment files
+from that folder. Copy `web/.env.local.example` to `web/.env.local` (or
+`web/.env`) and fill in your Firebase keys there; otherwise the frontend will
+start with an invalid API key and Firebase will raise `auth/invalid-api-key`
+errors. If these variables are omitted the app will still run, but login
+functionality will be disabled.
 
 When deploying the backend, set the `FRONTEND_ORIGINS` environment variable to
 the URL of your frontend (comma‑separated if multiple). This controls which

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,10 +1,11 @@
 # Copy this file to `.env.local` and replace with your keys.
 # Do not wrap values in quotes and avoid trailing spaces.
 # Example environment variables for Firebase auth
+# `NEXT_PUBLIC_FIREBASE_*` variables are also accepted; either form works.
 NEXT_PUBLIC_API_URL=http://localhost:8000
-NEXT_PUBLIC_FIREBASE_API_KEY=dummy_api_key
-NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=dummy_project.firebaseapp.com
-NEXT_PUBLIC_FIREBASE_PROJECT_ID=dummy_project
-NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
-NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=1234567890
-NEXT_PUBLIC_FIREBASE_APP_ID=1:1234567890:web:abcdef
+FIREBASE_API_KEY=dummy_api_key
+FIREBASE_AUTH_DOMAIN=dummy_project.firebaseapp.com
+FIREBASE_PROJECT_ID=dummy_project
+FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
+FIREBASE_MESSAGING_SENDER_ID=1234567890
+FIREBASE_APP_ID=1:1234567890:web:abcdef

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -14,7 +14,7 @@ export default function SaveHistoryButton({ data }: { data: any }) {
       const title = prompt(t('enterTitle')) || '';
       const isPublic = confirm(t('makePublic'));
       const payload = { data, created_at: new Date().toISOString(), title, is_public: isPublic };
-      if (user && firebaseEnabled) {
+      if (user && firebaseEnabled && db) {
         await addDoc(collection(db, 'users', user.uid, 'rankings'), payload);
       } else {
         await fetch(`${apiUrl}/history`, {

--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -9,7 +9,7 @@ export default function ShareButton({ data }: { data: any }) {
 
   const saveData = async (): Promise<string> => {
     let savedId: string | undefined;
-    if (user) {
+    if (user && db) {
       const docRef = await addDoc(collection(db, 'users', user.uid, 'rankings'), data);
       savedId = docRef.id;
     } else {

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,9 +1,32 @@
 /** @type {import('next').NextConfig} */
+const env = {
+  NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL,
+  NEXT_PUBLIC_FIREBASE_API_KEY:
+    process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? process.env.FIREBASE_API_KEY,
+  NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN:
+    process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN ??
+    process.env.FIREBASE_AUTH_DOMAIN,
+  NEXT_PUBLIC_FIREBASE_PROJECT_ID:
+    process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID ??
+    process.env.FIREBASE_PROJECT_ID,
+  NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET:
+    process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET ??
+    process.env.FIREBASE_STORAGE_BUCKET,
+  NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID:
+    process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID ??
+    process.env.FIREBASE_MESSAGING_SENDER_ID,
+  NEXT_PUBLIC_FIREBASE_APP_ID:
+    process.env.NEXT_PUBLIC_FIREBASE_APP_ID ?? process.env.FIREBASE_APP_ID,
+};
+
+Object.keys(env).forEach((key) => env[key] === undefined && delete env[key]);
+
 const nextConfig = {
   i18n: {
     locales: ['en', 'ja'],
     defaultLocale: 'en'
-  }
+  },
+  env,
 };
 
 module.exports = nextConfig;

--- a/web/pages/history.tsx
+++ b/web/pages/history.tsx
@@ -20,9 +20,11 @@ export default function HistoryPage() {
   const loadHistory = async () => {
     try {
       if (user) {
-        const snap = await getDocs(collection(db, 'users', user.uid, 'rankings'));
-        const arr = snap.docs.map((d) => ({ id: d.id, ...d.data() } as any));
-        setItems(arr);
+        if (db) {
+          const snap = await getDocs(collection(db, 'users', user.uid, 'rankings'));
+          const arr = snap.docs.map((d) => ({ id: d.id, ...d.data() } as any));
+          setItems(arr);
+        }
       } else {
         const res = await fetch(`${apiUrl}/history`);
         if (res.ok) {
@@ -37,7 +39,7 @@ export default function HistoryPage() {
 
   const handleDelete = async (id: string) => {
     try {
-      if (user) {
+      if (user && db) {
         await deleteDoc(doc(db, 'users', user.uid, 'rankings', id));
         setItems(items.filter((i) => i.id !== id));
       } else {

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -10,7 +10,7 @@ export default function Home() {
 
   useEffect(() => {
     const load = async () => {
-      if (user) {
+      if (user && db) {
         const q = query(collection(db, 'users', user.uid, 'rankings'), limit(3));
         const snap = await getDocs(q);
         setHistory(snap.docs.map((d) => ({ id: d.id, ...d.data() })));

--- a/web/pages/profile.tsx
+++ b/web/pages/profile.tsx
@@ -9,7 +9,7 @@ export default function Profile() {
 
   useEffect(() => {
     const load = async () => {
-      if (!user) return;
+      if (!user || !db) return;
       const snap = await getDocs(collection(db, 'users', user.uid, 'rankings'));
       setItems(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
     };


### PR DESCRIPTION
## Summary
- Map unprefixed `FIREBASE_*` variables to `NEXT_PUBLIC_FIREBASE_*` in Next.js config and document the option
- Update example env files and README for the new variable handling
- Guard Firestore calls behind a database check so builds succeed when Firebase is disabled

## Testing
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c597db2248323ba0ebeb2332685d8