### PR TITLE
fix: require login for history actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Run these commands from the `web` directory so that Next.js can read the environ
 - Confirm that `.env.local` lives in the `web` directory.
 - Ensure there are **no quotes or trailing spaces** around the values.
 - Restart `npm run dev` after editing the file so Next.js reloads the environment.
+- Saving or sharing rankings requires a logged-in user. Without the OAuth values above, those actions will trigger a login prompt and no data will be persisted.
 
 The `web` directory uses TypeScript with a standard `tsconfig.json` configured for Next.js. Run `npm run build` to compile the project for production or use `npx tsc --noEmit` to perform a type check only.
 

--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -7,6 +7,7 @@ interface AuthContextType {
   login: () => void;
   logout: () => void;
   authEnabled: boolean;
+  loading: boolean;
 }
 
 const AuthContext = createContext<AuthContextType>({
@@ -14,18 +15,20 @@ const AuthContext = createContext<AuthContextType>({
   login: () => {},
   logout: () => {},
   authEnabled: true,
+  loading: true,
 });
 
 export const useAuth = () => useContext(AuthContext);
 
 function InnerAuthProvider({ children }: { children: ReactNode }) {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const authEnabled = !!process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
   const value: AuthContextType = {
     user: session?.user ?? null,
     login: () => signIn('google'),
     logout: () => signOut(),
     authEnabled,
+    loading: status === 'loading',
   };
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -3,7 +3,7 @@ import { useAuth } from './AuthProvider';
 import { useTranslations } from 'next-intl';
 
 export default function Header() {
-  const { user, login, logout, authEnabled } = useAuth();
+  const { user, login, logout, authEnabled, loading } = useAuth();
   const t = useTranslations();
   return (
     <header className="p-4 flex justify-between items-center border-b mb-4">
@@ -14,28 +14,30 @@ export default function Header() {
         <Link href="/timeline">
           <span className="text-sm underline">{t('timeline')}</span>
         </Link>
-        {authEnabled ? (
-          user ? (
-          <>
-            <Link href="/profile">
-              <span className="text-sm underline">{t('profile')}</span>
-            </Link>
-            <button onClick={logout} className="px-3 py-1 bg-gray-600 text-white rounded">
-              {t('logout')}
-            </button>
-          </>
+        {!loading && (
+          authEnabled ? (
+            user ? (
+              <>
+                <Link href="/profile">
+                  <span className="text-sm underline">{t('profile')}</span>
+                </Link>
+                <button onClick={logout} className="px-3 py-1 bg-gray-600 text-white rounded">
+                  {t('logout')}
+                </button>
+              </>
+            ) : (
+              <button onClick={login} className="px-3 py-1 bg-blue-600 text-white rounded">
+                {t('login')}
+              </button>
+            )
           ) : (
-            <button onClick={login} className="px-3 py-1 bg-blue-600 text-white rounded">
+            <span
+              className="text-gray-500"
+              title="Auth not configured. See README for setup."
+            >
               {t('login')}
-            </button>
+            </span>
           )
-        ) : (
-          <span
-            className="text-gray-500"
-            title="Auth not configured. See README for setup."
-          >
-            {t('login')}
-          </span>
         )}
       </div>
     </header>

--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -1,10 +1,16 @@
 import { useTranslations } from 'next-intl';
+import { useAuth } from './AuthProvider';
 
 export default function SaveHistoryButton({ data }: { data: any }) {
   const t = useTranslations();
+  const { user, login, authEnabled } = useAuth();
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
   const handleSave = async () => {
+    if (authEnabled && !user) {
+      login();
+      return;
+    }
     try {
       const title = prompt(t('enterTitle')) || '';
       const isPublic = confirm(t('makePublic'));

--- a/web/components/ShareButton.tsx
+++ b/web/components/ShareButton.tsx
@@ -1,7 +1,9 @@
 import { useTranslations } from 'next-intl';
+import { useAuth } from './AuthProvider';
 
 export default function ShareButton({ data }: { data: any }) {
   const t = useTranslations();
+  const { user, login, authEnabled } = useAuth();
 
   const saveData = async (): Promise<string> => {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -14,7 +16,16 @@ export default function ShareButton({ data }: { data: any }) {
     return `${window.location.origin}/results?id=${saved.id}`;
   };
 
+  const requireAuth = async () => {
+    if (authEnabled && !user) {
+      login();
+      return false;
+    }
+    return true;
+  };
+
   const handleCopy = async () => {
+    if (!(await requireAuth())) return;
     try {
       const url = await saveData();
       await navigator.clipboard.writeText(url);
@@ -25,6 +36,7 @@ export default function ShareButton({ data }: { data: any }) {
   };
 
   const handleTweet = async () => {
+    if (!(await requireAuth())) return;
     try {
       const url = await saveData();
       const intent = `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}`;

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -3,6 +3,7 @@ const env = {
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL,
   NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID:
     process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID,
+  NEXTAUTH_URL: process.env.NEXTAUTH_URL,
 };
 
 Object.keys(env).forEach((key) => env[key] === undefined && delete env[key]);
@@ -10,7 +11,7 @@ Object.keys(env).forEach((key) => env[key] === undefined && delete env[key]);
 const nextConfig = {
   i18n: {
     locales: ['en', 'ja'],
-    defaultLocale: 'en'
+    defaultLocale: 'en',
   },
   env,
 };

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -1,7 +1,7 @@
-import NextAuth from 'next-auth';
+import NextAuth, { type NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 
-export const authOptions = {
+export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
       clientId: process.env.GOOGLE_OAUTH_CLIENT_ID!,

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '../components/AuthProvider'
 
 export default function Home() {
-  const { user } = useAuth();
+  const { user, authEnabled } = useAuth();
   const [history, setHistory] = useState<any[]>([]);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
@@ -15,8 +15,8 @@ export default function Home() {
         setHistory(data.slice(0, 3));
       }
     };
-    if (user) load();
-  }, [user]);
+    if (user && authEnabled) load();
+  }, [user, authEnabled]);
 
   return (
     <div className="max-w-[1140px] mx-auto px-4 text-center space-y-20">
@@ -73,7 +73,7 @@ export default function Home() {
         <h2 className="text-3xl font-bold">さあ、あなたの最初のランキングを作りましょう</h2>
         <Link href="/create" className="inline-block px-6 py-3 bg-primary text-white rounded-lg hover:bg-primary-dark text-xl">無料でランングを作成する</Link>
       </section>
-      {user && (
+      {user && authEnabled && (
         <section className="space-y-6">
           <h2 className="text-2xl font-bold">あなたのランキング履歴</h2>
           {history.length === 0 ? (

--- a/web/pages/profile.tsx
+++ b/web/pages/profile.tsx
@@ -2,11 +2,12 @@ import { useAuth } from '../components/AuthProvider';
 import { useEffect, useState } from 'react';
 
 export default function Profile() {
-  const { user } = useAuth();
+  const { user, authEnabled } = useAuth();
   const [items, setItems] = useState<any[]>([]);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
   useEffect(() => {
+    if (!user || !authEnabled) return;
     const load = async () => {
       const res = await fetch(`${apiUrl}/history`);
       if (res.ok) {
@@ -14,7 +15,7 @@ export default function Profile() {
       }
     };
     load();
-  }, []);
+  }, [user, authEnabled]);
 
   if (!user) {
     return <p className="p-4">Please login.</p>;


### PR DESCRIPTION
## Summary
- expose session loading state via `AuthProvider`
- block saving and sharing history unless user is logged in
- document that history actions require authentication

## Testing
- `npx tsc --noEmit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688db430164883239e681f2580c41209