### PR TITLE
fix: require auth before saving history

### DIFF
--- a/web/components/SaveHistoryButton.tsx
+++ b/web/components/SaveHistoryButton.tsx
@@ -7,7 +7,12 @@ export default function SaveHistoryButton({ data }: { data: any }) {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 
   const handleSave = async () => {
-    if (authEnabled && !user) {
+    if (!authEnabled) {
+      alert(t('authRequired'));
+      return;
+    }
+    if (!user) {
+      alert(t('authRequired'));
       login();
       return;
     }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -37,6 +37,7 @@
   "copyLink": "Copy link",
   "historyTitle": "History",
   "deleteHistory": "Delete",
+  "authRequired": "Login required to save",
   "login": "Login with Google",
   "logout": "Logout",
   "profile": "Profile",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -37,6 +37,7 @@
   "copyLink": "リンクをコピー",
   "historyTitle": "履歴",
   "deleteHistory": "削除",
+  "authRequired": "保存するにはログインが必要です",
   "login": "Googleでログイン",
   "logout": "ログアウト",
   "profile": "プロフィール",


### PR DESCRIPTION
## Summary
- block saving when auth is disabled or user not logged in
- add `authRequired` translation strings

## Testing
- `cd web && npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688db84d8f608323b993b3b9c4cacc93