### PR TITLE
Integrate i18n for profile page

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -43,5 +43,9 @@
   "enterTitle": "Enter ranking title",
   "makePublic": "Make this ranking public?",
   "timeline": "Public Rankings",
-  "timelineTitle": "Public Rankings"
+  "timelineTitle": "Public Rankings",
+  "pleaseLogin": "Please login.",
+  "welcome": "Welcome, {name}",
+  "yourRankings": "Your Rankings",
+  "noHistory": "No history"
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -43,5 +43,9 @@
   "enterTitle": "ランキングのタイトルを入力",
   "makePublic": "このランキングを公開しますか？",
   "timeline": "みんなのランキング",
-  "timelineTitle": "みんなのランキング"
+  "timelineTitle": "みんなのランキング",
+  "pleaseLogin": "ログインしてください",
+  "welcome": "ようこそ、{name}さん",
+  "yourRankings": "あなたのランキング",
+  "noHistory": "履歴はありません"
 }

--- a/web/pages/profile.tsx
+++ b/web/pages/profile.tsx
@@ -1,10 +1,12 @@
 import { useAuth } from '../components/AuthProvider';
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 
 export default function Profile() {
   const { user, authEnabled } = useAuth();
   const [items, setItems] = useState<any[]>([]);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const t = useTranslations();
 
   useEffect(() => {
     if (!user || !authEnabled) return;
@@ -18,16 +20,16 @@ export default function Profile() {
   }, [user, authEnabled]);
 
   if (!user) {
-    return <p className="p-4">Please login.</p>;
+    return <p className="p-4">{t('pleaseLogin')}</p>;
   }
 
   return (
     <div className="max-w-[1140px] mx-auto p-4 space-y-4">
-      <h1 className="text-2xl font-bold">Profile</h1>
-      <p>Welcome, {user.name}</p>
-      <h2 className="font-semibold">Your Rankings</h2>
+      <h1 className="text-2xl font-bold">{t('profile')}</h1>
+      <p>{t('welcome', { name: user.name })}</p>
+      <h2 className="font-semibold">{t('yourRankings')}</h2>
       {items.length === 0 ? (
-        <p>No history</p>
+        <p>{t('noHistory')}</p>
       ) : (
         <ul className="space-y-2">
           {items.map((i) => (


### PR DESCRIPTION
## Summary
- localize profile page strings and guard for unauthenticated access
- add missing translation keys for new messages

## Testing
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688db84fb8bc8323bf93beee610d51ba