### PR TITLE
fix: ensure auth provider runs on client

### DIFF
--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { createContext, useContext, ReactNode } from 'react';
 import { Session } from 'next-auth';
 import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';

--- a/web/components/Header.tsx
+++ b/web/components/Header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from 'next/link';
 import { useAuth } from './AuthProvider';
 import { useTranslations } from 'next-intl';

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import type { AppProps } from 'next/app';
 import { NextIntlClientProvider } from 'next-intl';
 import { useRouter } from 'next/router';


### PR DESCRIPTION
## Summary
- mark AuthProvider and related components as client components so next-auth hooks run properly

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e061310cc83238c8dd37fa486bcf6