### PR TITLE
chore: enable strict mode in next.js config

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -15,6 +15,7 @@ const nextConfig = {
     locales: ['en', 'ja'],
     defaultLocale: 'en',
   },
+  reactStrictMode: true,
   env,
   webpack: (config) => {
     config.resolve.alias = {


### PR DESCRIPTION
## Summary
- enable React's strict mode in Next.js config

## Testing
- `npm --prefix web run lint` *(fails: Missing script "lint")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e0d1f0998832381f269ee10802afc