### PR TITLE
fix: remove next.js aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cd web
 npm install
 npm run dev
 ```
-Run these commands from the `web` directory so that Next.js can read the environment variables located there. The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, and `NEXTAUTH_SECRET`). If these variables are missing, the login button will be disabled.
+Run these commands from the `web` directory so that dependencies like `next-auth` and `react` are installed locally. Relying on globally installed packages can cause module resolution or hook errors. The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, and `NEXTAUTH_SECRET`). If these variables are missing, the login button will be disabled.
 
 - Confirm that `.env.local` lives in the `web` directory.
 - Ensure there are **no quotes or trailing spaces** around the values.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,5 +1,4 @@
 /** @type {import('next').NextConfig} */
-const path = require('path');
 
 const env = {
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL,
@@ -17,15 +16,6 @@ const nextConfig = {
   },
   reactStrictMode: true,
   env,
-  webpack: (config) => {
-    config.resolve.alias = {
-      ...(config.resolve.alias || {}),
-      react: path.resolve('./node_modules/react'),
-      'react-dom': path.resolve('./node_modules/react-dom'),
-      'next-auth/react': path.resolve('./node_modules/next-auth/react'),
-    };
-    return config;
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- remove custom React/NextAuth aliases from Next.js config
- document installing web dependencies locally to avoid global package conflicts

## Testing
- `npm install`
- `npm ls react next-auth`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e61b523e88323bff56931dc464493