### PR TITLE
fix: remove next.js aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,8 @@ Next.js + FastAPI + GPT-4o で動く AI ランキングジェネレーター
 ## Development
 
 ### Web (Next.js)
-```
-cd web
-npm install
-npm run dev
-```
-Run these commands from the `web` directory so that Next.js can read the environment variables located there. The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, and `NEXTAUTH_SECRET`). If these variables are missing, the login button will be disabled.
 
-- Confirm that `.env.local` lives in the `web` directory.
-- Ensure there are **no quotes or trailing spaces** around the values.
-- Restart `npm run dev` after editing the file so Next.js reloads the environment.
-- Saving or sharing rankings requires a logged-in user. Without the OAuth values above, those actions will trigger a login prompt and no data will be persisted.
-
-The `web` directory uses TypeScript with a standard `tsconfig.json` configured for Next.js. Run `npm run build` to compile the project for production or use `npx tsc --noEmit` to perform a type check only.
+See [web/README.md](web/README.md) for setup and development instructions. Run all `npm` commands from the `web` directory so dependencies like `next-auth` and `react` are installed locally. Copy `web/.env.local.example` to `web/.env.local` and fill in the Google OAuth values before starting the app.
 
 ### Server (FastAPI)
 ```

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,40 @@
+# Web (Next.js)
+
+## Setup
+
+From the repository root run:
+
+```bash
+cd web
+npm install
+```
+
+Running `npm install` inside the `web` directory ensures packages like `next-auth`, `react`, and `react-dom` are installed locally. Using globally installed copies can lead to "Module not found" or "Invalid hook call" errors.
+
+After the install, confirm a single version of each dependency is present:
+
+```bash
+npm ls react react-dom next-auth
+```
+
+If any of these packages are missing or duplicated, remove `node_modules` and `package-lock.json` and install again.
+
+## Development
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+## Build
+
+Create a production build:
+
+```bash
+npm run build
+```
+
+## Environment variables
+
+Copy `.env.local.example` to `.env.local` and fill in the Google OAuth values before running the app. These values must live in the `web` directory and should have no quotes or trailing spaces.

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,5 +1,4 @@
 /** @type {import('next').NextConfig} */
-const path = require('path');
 
 const env = {
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL,
@@ -17,15 +16,6 @@ const nextConfig = {
   },
   reactStrictMode: true,
   env,
-  webpack: (config) => {
-    config.resolve.alias = {
-      ...(config.resolve.alias || {}),
-      react: path.resolve('./node_modules/react'),
-      'react-dom': path.resolve('./node_modules/react-dom'),
-      'next-auth/react': path.resolve('./node_modules/next-auth/react'),
-    };
-    return config;
-  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- remove custom React/NextAuth aliases from Next.js config
- document local dependency installation in dedicated `web/README.md` and reference it from root README

## Testing
- `pytest -q`
- `npm run build`
- `npm ls react react-dom next-auth`


------
https://chatgpt.com/codex/tasks/task_e_688e61b523e88323bff56931dc464493