### PR TITLE
fix: pass session to auth provider

### DIFF
--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -35,9 +35,15 @@ function InnerAuthProvider({ children }: { children: ReactNode }) {
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
-export function AuthProvider({ children }: { children: ReactNode }) {
+export function AuthProvider({
+  children,
+  session,
+}: {
+  children: ReactNode;
+  session?: Session | null;
+}) {
   return (
-    <SessionProvider>
+    <SessionProvider session={session}>
       <InnerAuthProvider>{children}</InnerAuthProvider>
     </SessionProvider>
   );

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import type { AppProps } from 'next/app';
+import type { Session } from 'next-auth';
 import { NextIntlClientProvider } from 'next-intl';
 import { useRouter } from 'next/router';
 import '../globals.css';
 import { AuthProvider } from '../components/AuthProvider';
 import Header from '../components/Header';
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+export default function MyApp({ Component, pageProps }: AppProps<{ session?: Session | null }>) {
   const { locale } = useRouter();
   const messages = require(`../messages/${locale}.json`);
   // Set a global default time zone to avoid server/client mismatches
   // See https://next-intl.dev/docs/configuration#time-zone
   const timeZone = process.env.NEXT_PUBLIC_TIME_ZONE || 'UTC';
   return (
-    <AuthProvider>
+    <AuthProvider session={pageProps.session}>
       <NextIntlClientProvider locale={locale!} messages={messages} timeZone={timeZone}>
         <Header />
         <Component {...pageProps} />


### PR DESCRIPTION
## Summary
- ensure AuthProvider forwards session to NextAuth's SessionProvider
- pass session from `_app` so hooks initialize correctly

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f4b5f47bc8323816f9c335f484d88