### PR TITLE
fix: wrap app layout in client SessionProvider

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,13 @@
+import '../globals.css';
+import { ReactNode } from 'react';
+import SessionProviderWrapper from './providers/SessionProviderWrapper';
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="ja">
+      <body>
+        <SessionProviderWrapper>{children}</SessionProviderWrapper>
+      </body>
+    </html>
+  );
+}

--- a/web/app/providers/SessionProviderWrapper.tsx
+++ b/web/app/providers/SessionProviderWrapper.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { SessionProvider } from 'next-auth/react';
+
+export default function SessionProviderWrapper({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- add client-side `SessionProviderWrapper`
- wrap App Router `layout.tsx` with the session provider

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688f51e77d3c8323afe81e85a71a8286