### PR TITLE
refactor auth session provider

### DIFF
--- a/web/app/providers/SessionProviderWrapper.tsx
+++ b/web/app/providers/SessionProviderWrapper.tsx
@@ -1,7 +1,21 @@
 'use client';
+
 import { ReactNode } from 'react';
+import { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 
-export default function SessionProviderWrapper({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+/**
+ * Wraps the NextAuth SessionProvider so that it can be used from both
+ * the App Router layout and the legacy `pages` router.  Accepts an
+ * optional Session object for initial hydration when rendered in
+ * `_app.tsx`.
+ */
+export default function SessionProviderWrapper({
+  children,
+  session,
+}: {
+  children: ReactNode;
+  session?: Session | null;
+}) {
+  return <SessionProvider session={session}>{children}</SessionProvider>;
 }

--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, ReactNode } from 'react';
 import { Session } from 'next-auth';
-import { SessionProvider, signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, signOut, useSession } from 'next-auth/react';
 
 interface AuthContextType {
   user: Session['user'] | null;
@@ -22,7 +22,7 @@ const AuthContext = createContext<AuthContextType>({
 
 export const useAuth = () => useContext(AuthContext);
 
-function InnerAuthProvider({ children }: { children: ReactNode }) {
+export function AuthProvider({ children }: { children: ReactNode }) {
   const { data: session, status } = useSession();
   const authEnabled = !!process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
   const value: AuthContextType = {
@@ -33,18 +33,4 @@ function InnerAuthProvider({ children }: { children: ReactNode }) {
     loading: status === 'loading',
   };
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
-}
-
-export function AuthProvider({
-  children,
-  session,
-}: {
-  children: ReactNode;
-  session?: Session | null;
-}) {
-  return (
-    <SessionProvider session={session}>
-      <InnerAuthProvider>{children}</InnerAuthProvider>
-    </SessionProvider>
-  );
 }

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -6,6 +6,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { useRouter } from 'next/router';
 import '../globals.css';
 import { AuthProvider } from '../components/AuthProvider';
+import SessionProviderWrapper from '../app/providers/SessionProviderWrapper';
 import Header from '../components/Header';
 
 export default function MyApp({ Component, pageProps }: AppProps<{ session?: Session | null }>) {
@@ -15,11 +16,13 @@ export default function MyApp({ Component, pageProps }: AppProps<{ session?: Ses
   // See https://next-intl.dev/docs/configuration#time-zone
   const timeZone = process.env.NEXT_PUBLIC_TIME_ZONE || 'UTC';
   return (
-    <AuthProvider session={pageProps.session}>
-      <NextIntlClientProvider locale={locale!} messages={messages} timeZone={timeZone}>
-        <Header />
-        <Component {...pageProps} />
-      </NextIntlClientProvider>
-    </AuthProvider>
+    <SessionProviderWrapper session={pageProps.session}>
+      <AuthProvider>
+        <NextIntlClientProvider locale={locale!} messages={messages} timeZone={timeZone}>
+          <Header />
+          <Component {...pageProps} />
+        </NextIntlClientProvider>
+      </AuthProvider>
+    </SessionProviderWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- support sharing next-auth SessionProvider via wrapper for app and pages routers
- simplify AuthProvider to consume session from context
- wrap pages `_app` with SessionProviderWrapper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f5fb2cba48323b0f7c46a226698e5