### PR TITLE
fix: dedupe react in turbopack

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -17,6 +17,19 @@ const nextConfig = {
   },
   reactStrictMode: true,
   env,
+  experimental: {
+    turbo: {
+      // Mirror the webpack aliases in Turbopack so that dev builds also
+      // resolve to the local React installation. Without this, Windows
+      // environments that have a global copy of React can end up loading
+      // two different React instances and trigger "Invalid hook call"
+      // errors at runtime.
+      resolveAlias: {
+        react: path.resolve(__dirname, './node_modules/react'),
+        'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
+      },
+    },
+  },
   webpack: (config) => {
     // Ensure all packages, including ones hoisted outside this project, use
     // the same React instance to avoid "Invalid hook call" errors.


### PR DESCRIPTION
## Summary
- ensure Turbopack resolves React and ReactDOM to the local project copy to avoid multiple React instances

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688f77fbbcf88323b9331a0320919fa0