### PR TITLE
fix: pin frontend dependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,23 +8,23 @@
       "name": "ranking-web",
       "version": "0.1.0",
       "dependencies": {
-        "chart.js": "^4.4.1",
-        "html2canvas": "^1.4.1",
-        "jspdf": "^2.5.1",
-        "lucide-react": "^0.379.0",
+        "chart.js": "4.4.1",
+        "html2canvas": "1.4.1",
+        "jspdf": "2.5.1",
+        "lucide-react": "0.379.0",
         "next": "14.0.4",
-        "next-auth": "^4.24.11",
+        "next-auth": "4.24.7",
         "next-intl": "3.4.0",
         "react": "18.2.0",
-        "react-chartjs-2": "^5.2.0",
+        "react-chartjs-2": "5.2.0",
         "react-dom": "18.2.0"
       },
       "devDependencies": {
         "@types/node": "22.15.30",
-        "@types/react": "^18.2.0",
-        "autoprefixer": "^10.4.21",
-        "postcss": "^8.5.4",
-        "tailwindcss": "^3.3.5",
+        "@types/react": "18.2.0",
+        "autoprefixer": "10.4.21",
+        "postcss": "8.5.4",
+        "tailwindcss": "3.3.5",
         "typescript": "5.8.3"
       }
     },
@@ -415,15 +415,23 @@
       "optional": true
     },
     "node_modules/@types/react": {
-      "version": "18.3.23",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
-      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
+        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
@@ -688,15 +696,15 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
-      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.1.tgz",
+      "integrity": "sha512-C74QN1bxwV1v2PEujhmKjOZ7iUM4w6BWs23Md/6aOZZSlwMzeCIDGuZay++rBgChYru7/+QFeoQW0fQoP534Dg==",
       "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
       "engines": {
-        "pnpm": ">=8"
+        "pnpm": ">=7"
       }
     },
     "node_modules/chokidar": {
@@ -774,9 +782,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -937,9 +945,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -1216,34 +1224,21 @@
       "license": "MIT"
     },
     "node_modules/jspdf": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
-      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
+        "@babel/runtime": "^7.14.0",
         "atob": "^2.1.2",
         "btoa": "^1.2.1",
-        "fflate": "^0.8.1"
+        "fflate": "^0.4.8"
       },
       "optionalDependencies": {
         "canvg": "^3.0.6",
         "core-js": "^3.6.0",
-        "dompurify": "^2.5.4",
+        "dompurify": "^2.2.0",
         "html2canvas": "^1.0.0-rc.5"
-      }
-    },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/lines-and-columns": {
@@ -1423,14 +1418,14 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.11",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
-      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "version": "4.24.7",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.7.tgz",
+      "integrity": "sha512-iChjE8ov/1K/z98gdKbn2Jw+2vLgJtVV39X+rCP5SGnVQuco7QOr19FRNGMIrD8d3LYhHWV9j9sKLzq1aDWWQQ==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.7.0",
+        "cookie": "^0.5.0",
         "jose": "^4.15.5",
         "oauth": "^0.9.15",
         "openid-client": "^5.4.0",
@@ -1439,16 +1434,12 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "@auth/core": "0.34.2",
-        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "next": "^12.2.5 || ^13 || ^14",
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18 || ^19",
-        "react-dom": "^17.0.2 || ^18 || ^19"
+        "react": "^17.0.2 || ^18",
+        "react-dom": "^17.0.2 || ^18"
       },
       "peerDependenciesMeta": {
-        "@auth/core": {
-          "optional": true
-        },
         "nodemailer": {
           "optional": true
         }
@@ -1674,9 +1665,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
       "dev": true,
       "funding": [
         {
@@ -1859,13 +1850,13 @@
       }
     },
     "node_modules/react-chartjs-2": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
-      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz",
+      "integrity": "sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": "^4.1.1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {
@@ -2223,34 +2214,34 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.3.5.tgz",
+      "integrity": "sha512-5SEZU4J7pxZgSkv7FP1zY8i2TIAOooNZ1e/OGtxIEv6GltpoiXUqWvLy89+a10qYTB1N5Ifkuw9lqQkN9sscvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
+        "chokidar": "^3.5.3",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
+        "fast-glob": "^3.3.0",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.21.6",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
+        "jiti": "^1.19.1",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
@@ -2258,6 +2249,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tailwindcss/node_modules/object-hash": {
@@ -2304,6 +2305,19 @@
         "ts-node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/text-segmentation": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,23 +8,23 @@
     "start": "next start"
   },
   "dependencies": {
-    "chart.js": "^4.4.1",
-    "html2canvas": "^1.4.1",
-    "jspdf": "^2.5.1",
-    "lucide-react": "^0.379.0",
+    "chart.js": "4.4.1",
+    "html2canvas": "1.4.1",
+    "jspdf": "2.5.1",
+    "lucide-react": "0.379.0",
     "next": "14.0.4",
-    "next-auth": "^4.24.11",
+    "next-auth": "4.24.7",
     "next-intl": "3.4.0",
     "react": "18.2.0",
-    "react-chartjs-2": "^5.2.0",
+    "react-chartjs-2": "5.2.0",
     "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@types/node": "22.15.30",
-    "@types/react": "^18.2.0",
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.4",
-    "tailwindcss": "^3.3.5",
+    "@types/react": "18.2.0",
+    "autoprefixer": "10.4.21",
+    "postcss": "8.5.4",
+    "tailwindcss": "3.3.5",
     "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- pin frontend dependencies (next 14.0.4, react 18.2.0, next-auth 4.24.7, etc.)
- regenerate package-lock with pinned versions

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f7ca252c0832382839283d48c6686