### PR TITLE
Enable Google OAuth configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ npm run dev
 ```
 Run these commands from the `web` directory so that dependencies like `next-auth` and `react` are installed locally.
 Relying on globally installed packages can cause module resolution or hook errors.
-The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, and `NEXTAUTH_SECRET`).
+The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`).
 If these variables are missing, the login button will be disabled.
 
 - Confirm that `.env.local` lives in the `web` directory.
 - Ensure there are **no quotes or trailing spaces** around the values.
 - Restart `npm run dev` after editing the file so Next.js reloads the environment.
+- Set `NEXTAUTH_URL` to the base URL of your site (e.g. `http://localhost:3000` during development).
 - Saving or sharing rankings requires a logged-in user. Without the OAuth values above, those actions will trigger a login prompt and no data will be persisted.
 
 The `web` directory uses TypeScript with a standard `tsconfig.json` configured for Next.js. Run `npm run build` to compile the project for production or use `npx tsc --noEmit` to perform a type check only.

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -2,8 +2,13 @@
 # Do not wrap values in quotes and avoid trailing spaces.
 # Example environment variables for Google OAuth via NextAuth
 NEXT_PUBLIC_API_URL=http://localhost:8000
-GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
-GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
 NEXTAUTH_SECRET=your_nextauth_secret
+NEXTAUTH_URL=http://localhost:3000
 # Client ID can be exposed in the browser for feature toggles
-NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
+# Legacy variable names also supported:
+# GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
+# GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
+# NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your_google_client_id

--- a/web/components/AuthProvider.tsx
+++ b/web/components/AuthProvider.tsx
@@ -24,7 +24,12 @@ export const useAuth = () => useContext(AuthContext);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const { data: session, status } = useSession();
-  const authEnabled = !!process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
+  // Expose the client ID to the browser so we can hide the login button
+  // when OAuth isn't configured. Support the old NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID
+  // for backward compatibility.
+  const authEnabled =
+    !!process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ||
+    !!process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
   const value: AuthContextType = {
     user: session?.user ?? null,
     login: () => signIn('google'),

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -3,8 +3,13 @@ const path = require('path');
 
 const env = {
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL,
-  NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID:
-    process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID,
+  // Expose the Google client ID to the browser. Support both the standard
+  // GOOGLE_CLIENT_ID naming and the older GOOGLE_OAUTH_CLIENT_ID names.
+  NEXT_PUBLIC_GOOGLE_CLIENT_ID:
+    process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ??
+    process.env.GOOGLE_CLIENT_ID ??
+    process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID ??
+    process.env.GOOGLE_OAUTH_CLIENT_ID,
   NEXTAUTH_URL: process.env.NEXTAUTH_URL,
 };
 

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -4,8 +4,13 @@ import GoogleProvider from 'next-auth/providers/google';
 export const authOptions: NextAuthOptions = {
   providers: [
     GoogleProvider({
-      clientId: process.env.GOOGLE_OAUTH_CLIENT_ID!,
-      clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET!,
+      // Support both the standard NextAuth variable names and the
+      // previous GOOGLE_OAUTH_* names for backward compatibility.
+      clientId:
+        process.env.GOOGLE_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID!,
+      clientSecret:
+        process.env.GOOGLE_CLIENT_SECRET ??
+        process.env.GOOGLE_OAUTH_CLIENT_SECRET!,
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,


### PR DESCRIPTION
## Summary
- support standard `GOOGLE_CLIENT_ID/SECRET` env vars while retaining legacy names
- expose Google client ID to the browser and enable login when OAuth is configured
- document required NextAuth variables including `NEXTAUTH_URL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f7f0f82388323a3bf9a2ef933ea9b