### PR TITLE
Add Node engine configuration for web app

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "ranking-web",
       "version": "0.1.0",
+      "engines": {
+        "node": "22.15.0"
+      },
       "dependencies": {
         "chart.js": "4.4.1",
         "html2canvas": "1.4.1",

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,9 @@
   "name": "ranking-web",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "22.15.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- specify Node 22.15.0 in web package manifest
- record Node engine in package lock file

## Testing
- `npm test` (fails: Missing script)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f83da6acc8323bda86027a3ef0202