### PR TITLE
docs: clarify NextAuth env config

### DIFF
--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,11 +1,16 @@
 # Copy this file to `.env.local` and replace with your keys.
 # Do not wrap values in quotes and avoid trailing spaces.
 # Example environment variables for Google OAuth via NextAuth
+# Base URL for the local API
 NEXT_PUBLIC_API_URL=http://localhost:8000
+
+# Required NextAuth environment variables
+NEXTAUTH_URL=http://localhost:3000
+# Should be a random 32+ character string
+NEXTAUTH_SECRET=your_nextauth_secret
+
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
-NEXTAUTH_SECRET=your_nextauth_secret
-NEXTAUTH_URL=http://localhost:3000
 # Client ID can be exposed in the browser for feature toggles
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
 # Legacy variable names also supported:


### PR DESCRIPTION
## Summary
- document required NextAuth vars and API base URL in web/.env.local.example

## Testing
- `npm run dev`
- `curl -s http://localhost:3000/api/auth/signin | grep -o 'Sign in with Google' | head -n 1`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688fc22edb2c8323988ca30ff4367921