### PR TITLE
fix: resolve React duplication and auth defaults

### DIFF
--- a/web/next.config.js
+++ b/web/next.config.js
@@ -10,7 +10,9 @@ const env = {
     process.env.GOOGLE_CLIENT_ID ??
     process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID ??
     process.env.GOOGLE_OAUTH_CLIENT_ID,
-  NEXTAUTH_URL: process.env.NEXTAUTH_URL,
+  // Provide a sensible default so NextAuth can run during local development
+  // without requiring the developer to set NEXTAUTH_URL explicitly.
+  NEXTAUTH_URL: process.env.NEXTAUTH_URL || 'http://localhost:3000',
 };
 
 Object.keys(env).forEach((key) => env[key] === undefined && delete env[key]);
@@ -32,6 +34,14 @@ const nextConfig = {
       resolveAlias: {
         react: path.resolve(__dirname, './node_modules/react'),
         'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
+        'react/jsx-runtime': path.resolve(
+          __dirname,
+          './node_modules/react/jsx-runtime.js'
+        ),
+        'react/jsx-dev-runtime': path.resolve(
+          __dirname,
+          './node_modules/react/jsx-dev-runtime.js'
+        ),
       },
     },
   },
@@ -42,6 +52,14 @@ const nextConfig = {
       ...(config.resolve.alias || {}),
       react: path.resolve(__dirname, './node_modules/react'),
       'react-dom': path.resolve(__dirname, './node_modules/react-dom'),
+      'react/jsx-runtime': path.resolve(
+        __dirname,
+        './node_modules/react/jsx-runtime.js'
+      ),
+      'react/jsx-dev-runtime': path.resolve(
+        __dirname,
+        './node_modules/react/jsx-dev-runtime.js'
+      ),
     };
     return config;
   },

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -1,5 +1,10 @@
 import NextAuth, { type NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
+import crypto from 'crypto';
+
+// Fallback to a generated secret in development so authentication still works
+// when NEXTAUTH_SECRET isn't explicitly configured.
+const devSecret = crypto.randomBytes(32).toString('hex');
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -13,7 +18,7 @@ export const authOptions: NextAuthOptions = {
         process.env.GOOGLE_OAUTH_CLIENT_SECRET!,
     }),
   ],
-  secret: process.env.NEXTAUTH_SECRET,
+  secret: process.env.NEXTAUTH_SECRET || devSecret,
 };
 
 export default NextAuth(authOptions);


### PR DESCRIPTION
## Summary
- avoid invalid hook call by aliasing React runtime modules
- provide dev defaults for NextAuth URL and secret

## Testing
- `pytest`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890cdd02f2083239d0c727561d62dcd