### PR TITLE
fix: align React and Next dependencies

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,7 +13,7 @@
         "jspdf": "2.5.1",
         "lucide-react": "0.379.0",
         "next": "14.0.4",
-        "next-auth": "4.24.7",
+        "next-auth": "4.24.11",
         "next-intl": "3.4.0",
         "react": "18.2.0",
         "react-chartjs-2": "5.2.0",
@@ -777,9 +777,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1426,14 +1426,14 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.7.tgz",
-      "integrity": "sha512-iChjE8ov/1K/z98gdKbn2Jw+2vLgJtVV39X+rCP5SGnVQuco7QOr19FRNGMIrD8d3LYhHWV9j9sKLzq1aDWWQQ==",
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.5.0",
+        "cookie": "^0.7.0",
         "jose": "^4.15.5",
         "oauth": "^0.9.15",
         "openid-client": "^5.4.0",
@@ -1442,12 +1442,16 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "next": "^12.2.5 || ^13 || ^14",
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18",
-        "react-dom": "^17.0.2 || ^18"
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
       },
       "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
         "nodemailer": {
           "optional": true
         }

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
     "jspdf": "2.5.1",
     "lucide-react": "0.379.0",
     "next": "14.0.4",
-    "next-auth": "4.24.7",
+    "next-auth": "4.24.11",
     "next-intl": "3.4.0",
     "react": "18.2.0",
     "react-chartjs-2": "5.2.0",


### PR DESCRIPTION
## Summary
- pin React, React DOM, Next.js and NextAuth to explicit versions
- regenerate lock file and node_modules for a consistent dependency tree

## Testing
- `npm ls react react-dom next next-auth`
- `npm run build`
- `npm run dev`
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d6fc09e08323a47408c6fac46c8d