### PR TITLE
Add NextAuth env variables to example config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@
 # frontend. Replace the placeholder values with your actual API keys.
 OPENAI_API_KEY=YOUR_OPENAI_API_KEY
 NEXT_PUBLIC_API_URL=http://localhost:8000
+# NextAuth Google OAuth credentials
+NEXTAUTH_URL=http://localhost:3000
+# Should be a random 32+ character string
+NEXTAUTH_SECRET=your_nextauth_secret
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
 # Firebase credentials.  Either the FIREBASE_* or NEXT_PUBLIC_FIREBASE_* forms
 # may be used.  The build system maps the former to the latter so the values are
 # available in the browser bundle.


### PR DESCRIPTION
## Summary
- document NextAuth Google OAuth env vars in `.env.example`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68917fe5d68483238d0378efcf0d4c61