### PR TITLE
Document NextAuth Google OAuth env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,18 @@ FIREBASE_PROJECT_ID=dummy_project
 FIREBASE_STORAGE_BUCKET=dummy_project.appspot.com
 FIREBASE_MESSAGING_SENDER_ID=1234567890
 FIREBASE_APP_ID=1:1234567890:web:abcdef
+
+# NextAuth configuration for Google OAuth
+NEXTAUTH_URL=http://localhost:3000
+# Should be a random 32+ character string
+NEXTAUTH_SECRET=your_nextauth_secret
+
+# Google OAuth credentials. Either the standard GOOGLE_* variables or the
+# legacy GOOGLE_OAUTH_* names may be used.
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
+# Legacy variable names also supported:
+# GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
+# GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
+# NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your_google_client_id

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev
 ```
 Run these commands from the `web` directory so that dependencies like `next-auth` and `react` are installed locally.
 Relying on globally installed packages can cause module resolution or hook errors.
-The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`).
+The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`). For backward compatibility the legacy `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` variables are also supported.
 If these variables are missing, the login button will be disabled.
 
 - Confirm that `.env.local` lives in the `web` directory.


### PR DESCRIPTION
## Summary
- document required NextAuth + Google OAuth environment variables
- mention legacy GOOGLE_OAUTH_* variables in README

## Testing
- `cd server && pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68917fe5d68483238d0378efcf0d4c61