### PR TITLE
chore: use new Google client ID env name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXTAUTH_URL=http://localhost:3000
 # Should be a random 32+ character string
 NEXTAUTH_SECRET=your_nextauth_secret
-GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_ID_NEW=your_google_client_id
 GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
 # Firebase credentials.  Either the FIREBASE_* or NEXT_PUBLIC_FIREBASE_* forms
 # may be used.  The build system maps the former to the latter so the values are
@@ -23,12 +23,13 @@ NEXTAUTH_URL=http://localhost:3000
 # Should be a random 32+ character string
 NEXTAUTH_SECRET=your_nextauth_secret
 
-# Google OAuth credentials. Either the standard GOOGLE_* variables or the
-# legacy GOOGLE_OAUTH_* names may be used.
-GOOGLE_CLIENT_ID=your_google_client_id
+# Google OAuth credentials. Either the new GOOGLE_CLIENT_ID_NEW variable, the
+# standard GOOGLE_CLIENT_ID, or the legacy GOOGLE_OAUTH_* names may be used.
+GOOGLE_CLIENT_ID_NEW=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
 # Legacy variable names also supported:
+# GOOGLE_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
 # NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your_google_client_id

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev
 ```
 Run these commands from the `web` directory so that dependencies like `next-auth` and `react` are installed locally.
 Relying on globally installed packages can cause module resolution or hook errors.
-The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`). For backward compatibility the legacy `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` variables are also supported.
+The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID_NEW`, `GOOGLE_CLIENT_SECRET`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`). For backward compatibility the older `GOOGLE_CLIENT_ID` and legacy `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` variables are also supported.
 If these variables are missing, the login button will be disabled.
 
 - Confirm that `.env.local` lives in the `web` directory.

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -9,11 +9,12 @@ NEXTAUTH_URL=http://localhost:3000
 # Should be a random 32+ character string
 NEXTAUTH_SECRET=your_nextauth_secret
 
-GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_ID_NEW=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 # Client ID can be exposed in the browser for feature toggles
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
 # Legacy variable names also supported:
+# GOOGLE_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
 # NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your_google_client_id

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -3,10 +3,12 @@ const path = require('path');
 
 const env = {
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL,
-  // Expose the Google client ID to the browser. Support both the standard
-  // GOOGLE_CLIENT_ID naming and the older GOOGLE_OAUTH_CLIENT_ID names.
+  // Expose the Google client ID to the browser. Support the new
+  // GOOGLE_CLIENT_ID_NEW naming along with the previous GOOGLE_CLIENT_ID and
+  // legacy GOOGLE_OAUTH_CLIENT_ID names.
   NEXT_PUBLIC_GOOGLE_CLIENT_ID:
     process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ??
+    process.env.GOOGLE_CLIENT_ID_NEW ??
     process.env.GOOGLE_CLIENT_ID ??
     process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID ??
     process.env.GOOGLE_OAUTH_CLIENT_ID,

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -10,14 +10,16 @@ const devSecret = crypto.randomBytes(32).toString('hex');
 // they are missing. This helps surface misconfigured `.env` files which would
 // otherwise result in a cryptic "client_id is required" error.
 const googleClientId =
-  process.env.GOOGLE_CLIENT_ID ?? process.env.GOOGLE_OAUTH_CLIENT_ID;
+  process.env.GOOGLE_CLIENT_ID_NEW ??
+  process.env.GOOGLE_CLIENT_ID ??
+  process.env.GOOGLE_OAUTH_CLIENT_ID;
 const googleClientSecret =
   process.env.GOOGLE_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
 
 // Fail fast if the expected OAuth credentials are not configured.
 if (!googleClientId || !googleClientSecret) {
   throw new Error(
-    'Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.',
+    'Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID_NEW and GOOGLE_CLIENT_SECRET.',
   );
 }
 


### PR DESCRIPTION
## Summary
- adopt `GOOGLE_CLIENT_ID_NEW` for Google OAuth configuration
- surface new variable in docs and example env files
- expose the new env name in Next.js config and NextAuth provider

## Testing
- `pytest -q`
- `cd web && GOOGLE_CLIENT_ID_NEW=dummy GOOGLE_CLIENT_SECRET=dummy NEXTAUTH_URL=http://localhost:3000 NEXTAUTH_SECRET=secret NEXT_PUBLIC_GOOGLE_CLIENT_ID=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68938def167c832393d830ad740c61ef