### PR TITLE
feat: support new google oauth env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@ NEXTAUTH_URL=http://localhost:3000
 # Should be a random 32+ character string
 NEXTAUTH_SECRET=your_nextauth_secret
 GOOGLE_CLIENT_ID_NEW=your_google_client_id
-GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_SECRET_NEW=your_google_client_secret
+GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/callback/google
 # Firebase credentials.  Either the FIREBASE_* or NEXT_PUBLIC_FIREBASE_* forms
 # may be used.  The build system maps the former to the latter so the values are
 # available in the browser bundle.
@@ -26,9 +27,11 @@ NEXTAUTH_SECRET=your_nextauth_secret
 # Google OAuth credentials. Either the new GOOGLE_CLIENT_ID_NEW variable, the
 # standard GOOGLE_CLIENT_ID, or the legacy GOOGLE_OAUTH_* names may be used.
 GOOGLE_CLIENT_ID_NEW=your_google_client_id
-GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_SECRET_NEW=your_google_client_secret
+GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/callback/google
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
 # Legacy variable names also supported:
+# GOOGLE_CLIENT_SECRET=your_google_client_secret
 # GOOGLE_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm run dev
 ```
 Run these commands from the `web` directory so that dependencies like `next-auth` and `react` are installed locally.
 Relying on globally installed packages can cause module resolution or hook errors.
-The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID_NEW`, `GOOGLE_CLIENT_SECRET`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`). For backward compatibility the older `GOOGLE_CLIENT_ID` and legacy `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` variables are also supported.
+The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID_NEW`, `GOOGLE_CLIENT_SECRET_NEW`, `GOOGLE_REDIRECT_URI`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`). For backward compatibility the older `GOOGLE_CLIENT_ID` and legacy `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` variables are also supported.
 If these variables are missing, the login button will be disabled.
 
 - Confirm that `.env.local` lives in the `web` directory.

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -10,10 +10,12 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your_nextauth_secret
 
 GOOGLE_CLIENT_ID_NEW=your_google_client_id
-GOOGLE_CLIENT_SECRET=your_google_client_secret
+GOOGLE_CLIENT_SECRET_NEW=your_google_client_secret
+GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/callback/google
 # Client ID can be exposed in the browser for feature toggles
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
 # Legacy variable names also supported:
+# GOOGLE_CLIENT_SECRET=your_google_client_secret
 # GOOGLE_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -14,12 +14,15 @@ const googleClientId =
   process.env.GOOGLE_CLIENT_ID ??
   process.env.GOOGLE_OAUTH_CLIENT_ID;
 const googleClientSecret =
-  process.env.GOOGLE_CLIENT_SECRET ?? process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+  process.env.GOOGLE_CLIENT_SECRET_NEW ??
+  process.env.GOOGLE_CLIENT_SECRET ??
+  process.env.GOOGLE_OAUTH_CLIENT_SECRET;
+const googleRedirectUri = process.env.GOOGLE_REDIRECT_URI;
 
 // Fail fast if the expected OAuth credentials are not configured.
 if (!googleClientId || !googleClientSecret) {
   throw new Error(
-    'Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID_NEW and GOOGLE_CLIENT_SECRET.',
+    'Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID_NEW and GOOGLE_CLIENT_SECRET_NEW.',
   );
 }
 
@@ -28,6 +31,9 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: googleClientId,
       clientSecret: googleClientSecret,
+      authorization: googleRedirectUri
+        ? { params: { redirect_uri: googleRedirectUri } }
+        : undefined,
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET || devSecret,


### PR DESCRIPTION
## Summary
- support `GOOGLE_CLIENT_SECRET_NEW` and optional `GOOGLE_REDIRECT_URI`
- document new Google OAuth variables in sample env files
- mention updated env vars in README

## Testing
- `npx tsc --noEmit`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68939acc04708323b63690fe2d238381