### PR TITLE
docs: add invalid_client troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ If these variables are missing, the login button will be disabled.
 - Set `GOOGLE_REDIRECT_URI` to the full callback URL (e.g. `http://localhost:3000/api/auth/callback/google`).
 - Saving or sharing rankings requires a logged-in user. Without the OAuth values above, those actions will trigger a login prompt and no data will be persisted.
 
+#### Troubleshooting
+
+If Google OAuth returns an `invalid_client` error:
+
+- Verify that `GOOGLE_CLIENT_ID_NEW` and `GOOGLE_CLIENT_SECRET_NEW` (or the legacy variables) match the values in the Google Cloud Console. Update the values and restart `npm run dev`.
+- Ensure `GOOGLE_REDIRECT_URI` matches an Authorized redirect URI in the Google Cloud Console, including protocol and path. Update `.env.local` or the console settings and restart the app.
+- Use OAuth credentials created as a *Web application*. If a different type was used, create new web credentials and update `.env.local`.
+
 The `web` directory uses TypeScript with a standard `tsconfig.json` configured for Next.js. Run `npm run build` to compile the project for production or use `npx tsc --noEmit` to perform a type check only.
 
 ### Server (FastAPI)


### PR DESCRIPTION
## Summary
- document invalid_client causes and fixes for Google OAuth
- standardize troubleshooting list to match surrounding style

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893aa3c9854832382a96395c6b6438e