### PR TITLE
docs: standardize Google OAuth env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,21 @@ npm run dev
 ```
 Run these commands from the `web` directory so that dependencies like `next-auth` and `react` are installed locally.
 Relying on globally installed packages can cause module resolution or hook errors.
-The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID_NEW`, `GOOGLE_CLIENT_SECRET_NEW`, `GOOGLE_REDIRECT_URI`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`). For backward compatibility the older `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and the legacy `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` variables are also supported.
+The `.env.local` file is git-ignored, so copy `web/.env.local.example` to `web/.env.local` and replace the placeholder values with your actual Google OAuth credentials (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `NEXTAUTH_SECRET`, and `NEXTAUTH_URL`). Optionally set `GOOGLE_REDIRECT_URI` to override the default callback. For backward compatibility the older `GOOGLE_CLIENT_ID_NEW`, `GOOGLE_CLIENT_SECRET_NEW`, and the legacy `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` variables are also supported.
 If these variables are missing, the login button will be disabled.
 
 - Confirm that `.env.local` lives in the `web` directory.
 - Ensure there are **no quotes or trailing spaces** around the values.
 - Restart `npm run dev` after editing the file so Next.js reloads the environment.
 - Set `NEXTAUTH_URL` to the base URL of your site (e.g. `http://localhost:3000` during development).
-- Set `GOOGLE_REDIRECT_URI` to the full callback URL (e.g. `http://localhost:3000/api/auth/callback/google`).
+- The default callback is `http://localhost:3000/api/auth/callback/google`. If you use a different URL, set `GOOGLE_REDIRECT_URI` to the full callback path.
 - Saving or sharing rankings requires a logged-in user. Without the OAuth values above, those actions will trigger a login prompt and no data will be persisted.
 
 #### Troubleshooting
 
 If Google OAuth returns an `invalid_client` error:
 
-- **Wrong client ID or secret**: Verify that `GOOGLE_CLIENT_ID_NEW` and `GOOGLE_CLIENT_SECRET_NEW` (or the legacy variables) exactly match the values in the Google Cloud Console. Update the values and restart `npm run dev`.
+- **Wrong client ID or secret**: Verify that `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` (or the fallback variables) exactly match the values in the Google Cloud Console. Update the values and restart `npm run dev`.
 - **Redirect URI mismatch**: Ensure `GOOGLE_REDIRECT_URI` matches an Authorized redirect URI in the Google Cloud Console, including protocol and path. Update `.env.local` or the console settings and restart `npm run dev`.
 - **Incorrect OAuth client type**: Use OAuth credentials created as a *Web application*. If a different type was used, create new web credentials and update `.env.local`.
 

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -9,14 +9,15 @@ NEXTAUTH_URL=http://localhost:3000
 # Should be a random 32+ character string
 NEXTAUTH_SECRET=your_nextauth_secret
 
-GOOGLE_CLIENT_ID_NEW=your_google_client_id
-GOOGLE_CLIENT_SECRET_NEW=your_google_client_secret
-GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/callback/google
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret
 # Client ID can be exposed in the browser for feature toggles
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=your_google_client_id
+# Optional: override the default callback URL
+# GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/callback/google
 # Legacy variable names also supported:
-# GOOGLE_CLIENT_ID=your_google_client_id
-# GOOGLE_CLIENT_SECRET=your_google_client_secret
+# GOOGLE_CLIENT_ID_NEW=your_google_client_id
+# GOOGLE_CLIENT_SECRET_NEW=your_google_client_secret
 # GOOGLE_OAUTH_CLIENT_ID=your_google_client_id
 # GOOGLE_OAUTH_CLIENT_SECRET=your_google_client_secret
 # NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID=your_google_client_id

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -3,13 +3,13 @@ const path = require('path');
 
 const env = {
   NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL ?? process.env.API_URL,
-  // Expose the Google client ID to the browser. Support the new
-  // GOOGLE_CLIENT_ID_NEW naming along with the previous GOOGLE_CLIENT_ID and
-  // legacy GOOGLE_OAUTH_CLIENT_ID names.
+  // Expose the Google client ID to the browser. Support the default
+  // GOOGLE_CLIENT_ID name along with the legacy GOOGLE_CLIENT_ID_NEW and
+  // GOOGLE_OAUTH_CLIENT_ID variants.
   NEXT_PUBLIC_GOOGLE_CLIENT_ID:
     process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ??
-    process.env.GOOGLE_CLIENT_ID_NEW ??
     process.env.GOOGLE_CLIENT_ID ??
+    process.env.GOOGLE_CLIENT_ID_NEW ??
     process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID ??
     process.env.GOOGLE_OAUTH_CLIENT_ID,
   // Provide a sensible default so NextAuth can run during local development

--- a/web/pages/api/auth/[...nextauth].ts
+++ b/web/pages/api/auth/[...nextauth].ts
@@ -10,19 +10,19 @@ const devSecret = crypto.randomBytes(32).toString('hex');
 // they are missing. This helps surface misconfigured `.env` files which would
 // otherwise result in a cryptic "client_id is required" error.
 const googleClientId =
-  process.env.GOOGLE_CLIENT_ID_NEW ??
   process.env.GOOGLE_CLIENT_ID ??
+  process.env.GOOGLE_CLIENT_ID_NEW ??
   process.env.GOOGLE_OAUTH_CLIENT_ID;
 const googleClientSecret =
-  process.env.GOOGLE_CLIENT_SECRET_NEW ??
   process.env.GOOGLE_CLIENT_SECRET ??
+  process.env.GOOGLE_CLIENT_SECRET_NEW ??
   process.env.GOOGLE_OAUTH_CLIENT_SECRET;
 const googleRedirectUri = process.env.GOOGLE_REDIRECT_URI;
 
 // Fail fast if the expected OAuth credentials are not configured.
 if (!googleClientId || !googleClientSecret) {
   throw new Error(
-    'Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID_NEW and GOOGLE_CLIENT_SECRET_NEW.',
+    'Missing Google OAuth environment variables. Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.',
   );
 }
 


### PR DESCRIPTION
## Summary
- use default `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` names
- keep legacy env vars as fallbacks in NextAuth and config
- document optional `GOOGLE_REDIRECT_URI` and update README

## Testing
- `pytest -q`
- `GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy NEXTAUTH_SECRET=dummy NEXTAUTH_URL=http://localhost:3000 npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68963ecd47388323808351e337f71af8