### PR TITLE
Add NextAuth env example and ignore local env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 __pycache__
 *.pyc
 .env
+.env.local
 
 # Misc
 .DS_Store

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,4 @@
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=changeme_32chars_or_more
+GOOGLE_CLIENT_ID=your_google_client_id
+GOOGLE_CLIENT_SECRET=your_google_client_secret


### PR DESCRIPTION
## Summary
- ignore `.env.local` files
- add `web/.env.example` for NextAuth/Google OAuth setup

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689829a1b8b08323b72f6b679eeb9fdb