### PR TITLE
feat: add social posting schema and APIs

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -2,3 +2,4 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=changeme_32chars_or_more
 GOOGLE_CLIENT_ID=your_google_client_id   # WebアプリのClient ID
 GOOGLE_CLIENT_SECRET=your_google_client_secret
+DATABASE_URL="file:./dev.db"

--- a/web/app/api/og/post/[id]/route.ts
+++ b/web/app/api/og/post/[id]/route.ts
@@ -1,0 +1,33 @@
+import { ImageResponse } from '@vercel/og';
+import { prisma } from '@/lib/prisma';
+
+export const runtime = 'edge';
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const post = await prisma.post.findUnique({
+    where: { id: params.id },
+    include: { ranking: true }
+  });
+  if (!post || !post.ranking) return new Response('Not found', { status: 404 });
+  const items = (post.ranking.items as any[]).slice(0, 3).map((i: any) => i.name).join(' / ');
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 48,
+          background: 'white',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          padding: 48,
+          justifyContent: 'center',
+        }}
+      >
+        <div style={{ fontWeight: 'bold', marginBottom: 24 }}>{post.ranking.title}</div>
+        <div>{items}</div>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  );
+}

--- a/web/app/api/posts/[id]/comments/route.ts
+++ b/web/app/api/posts/[id]/comments/route.ts
@@ -1,0 +1,30 @@
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const rows = await prisma.comment.findMany({
+    where: { postId: params.id },
+    orderBy: { createdAt: 'desc' },
+    take: 50,
+    select: {
+      id: true,
+      body: true,
+      createdAt: true,
+      user: { select: { id: true, name: true, image: true, handle: true } }
+    }
+  });
+  return NextResponse.json(rows);
+}
+
+export async function POST(req: Request, { params }: { params: { id: string } }) {
+  const session = await getServerSession();
+  if (!session?.user?.id) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const { body } = (await req.json()) as { body: string };
+  if (!body?.trim()) return NextResponse.json({ error: 'invalid' }, { status: 400 });
+
+  const created = await prisma.comment.create({
+    data: { userId: session.user.id, postId: params.id, body }
+  });
+  return NextResponse.json({ id: created.id }, { status: 201 });
+}

--- a/web/app/api/posts/[id]/like/route.ts
+++ b/web/app/api/posts/[id]/like/route.ts
@@ -1,0 +1,17 @@
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const session = await getServerSession();
+  if (!session?.user?.id) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  await prisma.like.create({ data: { userId: session.user.id, postId: params.id } });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  const session = await getServerSession();
+  if (!session?.user?.id) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  await prisma.like.delete({ where: { userId_postId: { userId: session.user.id, postId: params.id } } });
+  return NextResponse.json({ ok: true });
+}

--- a/web/app/api/posts/create/route.ts
+++ b/web/app/api/posts/create/route.ts
@@ -1,0 +1,23 @@
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const session = await getServerSession();
+  if (!session?.user?.id) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const { rankingId, caption, tags } = (await req.json()) as {
+    rankingId: string;
+    caption?: string;
+    tags?: string[];
+  };
+  if (!rankingId) return NextResponse.json({ error: 'invalid' }, { status: 400 });
+  const created = await prisma.post.create({
+    data: {
+      userId: session.user.id,
+      rankingId,
+      caption,
+      tags: tags || [],
+    },
+  });
+  return NextResponse.json({ id: created.id }, { status: 201 });
+}

--- a/web/app/api/posts/route.ts
+++ b/web/app/api/posts/route.ts
@@ -1,0 +1,46 @@
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const cursor = searchParams.get('cursor');
+  const take = 20;
+  const session = await getServerSession();
+
+  const posts = await prisma.post.findMany({
+    where: { ranking: { isPublic: true } },
+    include: {
+      user: { select: { id: true, name: true, image: true, handle: true } },
+      ranking: { select: { id: true, title: true, items: true } },
+      _count: { select: { likes: true, comments: true } },
+      likes: session?.user?.id
+        ? { where: { userId: session.user.id }, select: { userId: true } }
+        : false,
+    },
+    orderBy: { createdAt: 'desc' },
+    take: take + 1,
+    cursor: cursor ? { id: cursor } : undefined,
+    skip: cursor ? 1 : 0,
+  });
+
+  let nextCursor: string | null = null;
+  if (posts.length > take) {
+    const next = posts.pop();
+    nextCursor = next!.id;
+  }
+
+  const data = posts.map(p => ({
+    id: p.id,
+    user: p.user,
+    ranking: p.ranking,
+    caption: p.caption,
+    tags: p.tags,
+    createdAt: p.createdAt,
+    likeCount: p._count.likes,
+    commentCount: p._count.comments,
+    likedByMe: !!p.likes?.length,
+  }));
+
+  return NextResponse.json({ posts: data, nextCursor });
+}

--- a/web/app/api/users/[handle]/follow/route.ts
+++ b/web/app/api/users/[handle]/follow/route.ts
@@ -1,0 +1,21 @@
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function POST(_: Request, { params }: { params: { handle: string } }) {
+  const session = await getServerSession();
+  if (!session?.user?.id) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const target = await prisma.user.findUnique({ where: { handle: params.handle } });
+  if (!target) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  await prisma.follow.create({ data: { followerId: session.user.id, followingId: target.id } });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(_: Request, { params }: { params: { handle: string } }) {
+  const session = await getServerSession();
+  if (!session?.user?.id) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const target = await prisma.user.findUnique({ where: { handle: params.handle } });
+  if (!target) return NextResponse.json({ error: 'not found' }, { status: 404 });
+  await prisma.follow.delete({ where: { followerId_followingId: { followerId: session.user.id, followingId: target.id } } });
+  return NextResponse.json({ ok: true });
+}

--- a/web/app/api/users/me/route.ts
+++ b/web/app/api/users/me/route.ts
@@ -1,0 +1,20 @@
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const session = await getServerSession();
+  if (!session?.user?.id) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: {
+      id: true,
+      name: true,
+      image: true,
+      handle: true,
+      bio: true,
+      _count: { select: { posts: true, followers: true, following: true } }
+    }
+  });
+  return NextResponse.json(user);
+}

--- a/web/components/social/PostCard.tsx
+++ b/web/components/social/PostCard.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { motion } from 'framer-motion';
+import { useState } from 'react';
+
+export function PostCard({ post }: { post: any }) {
+  const [liked, setLiked] = useState(post.likedByMe);
+  const [likes, setLikes] = useState(post.likeCount);
+
+  async function toggleLike() {
+    setLiked(v => !v);
+    setLikes(n => (liked ? n - 1 : n + 1));
+    const method = liked ? 'DELETE' : 'POST';
+    await fetch(`/api/posts/${post.id}/like`, { method });
+  }
+
+  return (
+    <motion.article whileHover={{ y: -4 }} className="rounded-2xl border border-slate-200 bg-white shadow-md p-4">
+      <header className="flex items-center gap-3 mb-3">
+        <img src={post.user.image} className="h-9 w-9 rounded-full" />
+        <div>
+          <a href={`/u/${post.user.handle || post.user.id}`} className="font-semibold">{post.user.name}</a>
+          <div className="text-xs text-slate-500">@{post.user.handle}</div>
+        </div>
+      </header>
+
+      <a href={`/r/${post.rankingId}`} className="block rounded-xl border bg-slate-50 p-3 mb-3">
+        <div className="font-bold">{post.ranking.title}</div>
+        <div className="text-sm text-slate-600 mt-1">上位: {post.ranking.items.slice(0,3).map((i:any)=>i.name).join('・')}</div>
+      </a>
+
+      {post.caption && <p className="text-slate-800 text-sm whitespace-pre-wrap mb-3">{post.caption}</p>}
+
+      <div className="flex items-center gap-4 text-sm">
+        <button onClick={toggleLike} className="flex items-center gap-1">
+          <span className={`material-icons ${liked ? 'text-rose-500' : 'text-slate-500'}`}>{liked ? 'favorite' : 'favorite_border'}</span>
+          <span>{likes}</span>
+        </button>
+        <a href={`/r/${post.rankingId}#comments`} className="flex items-center gap-1 text-slate-500">
+          <span className="material-icons">chat_bubble_outline</span>
+          <span>{post.commentCount}</span>
+        </a>
+        <button onClick={() => navigator.clipboard.writeText(location.origin + '/r/' + post.rankingId)} className="ml-auto text-slate-500">共有</button>
+      </div>
+    </motion.article>
+  );
+}

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -1,0 +1,6 @@
+import { getServerSession as originalGetServerSession } from 'next-auth';
+import { authOptions } from '@/pages/api/auth/[...nextauth]';
+
+export function getServerSession() {
+  return originalGetServerSession(authOptions);
+}

--- a/web/lib/prisma.ts
+++ b/web/lib/prisma.ts
@@ -1,0 +1,9 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,17 +8,23 @@
       "name": "ranking-web",
       "version": "0.1.0",
       "dependencies": {
+        "@prisma/client": "^5.16.1",
+        "@vercel/og": "^0.6.2",
         "chart.js": "4.4.1",
+        "date-fns": "^3.6.0",
         "envalid": "^8.1.0",
+        "framer-motion": "^11.2.10",
         "html2canvas": "1.4.1",
         "jspdf": "2.5.1",
         "lucide-react": "0.379.0",
         "next": "14.2.5",
         "next-auth": "4.24.11",
         "next-intl": "3.4.0",
+        "prisma": "^5.16.1",
         "react": "18.3.1",
         "react-chartjs-2": "5.2.0",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/node": "22.15.30",
@@ -411,6 +417,100 @@
         "node": ">=14"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/fetch-engine": "5.22.0",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0",
+        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+        "@prisma/get-platform": "5.22.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "5.22.0"
+      }
+    },
+    "node_modules/@resvg/resvg-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.4.0.tgz",
+      "integrity": "sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@shuding/opentype.js": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+      "integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.7.3",
+        "string.prototype.codepointat": "^0.2.1"
+      },
+      "bin": {
+        "ot": "bin/ot"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@shuding/opentype.js/node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -498,6 +598,20 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vercel/og": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@vercel/og/-/og-0.6.8.tgz",
+      "integrity": "sha512-e4kQK9mP8ntpo3dACWirGod/hHv4qO5JMj9a/0a2AZto7b4persj5YP7t1Er372gTtYFTYxNhMx34jRvHooglw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@resvg/resvg-wasm": "2.4.0",
+        "satori": "0.12.2",
+        "yoga-wasm-web": "0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/acorn": {
@@ -646,6 +760,15 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -746,6 +869,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/caniuse-lite": {
@@ -861,7 +993,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -917,6 +1048,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-background-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+      "integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+      "license": "MIT"
+    },
+    "node_modules/css-box-shadow": {
+      "version": "1.0.0-3",
+      "resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+      "integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+      "license": "MIT"
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-gradient-parser": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.16.tgz",
+      "integrity": "sha512-3O5QdqgFRUbXvK1x5INf1YkBz1UKSWqrd63vWsum8MNHDBYD5urm3QtxZbKU259OrEXNM26lP/MPY3d1IGkBgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/css-line-break": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
@@ -924,6 +1085,17 @@
       "license": "MIT",
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -945,6 +1117,16 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/decimal.js": {
       "version": "10.6.0",
@@ -1025,6 +1207,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1116,11 +1304,37 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1192,6 +1406,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hex-rgb": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+      "integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html2canvas": {
@@ -1370,6 +1596,16 @@
         "url": "https://github.com/sponsors/antonk52"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -1466,6 +1702,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -1720,6 +1971,22 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
+    "node_modules/parse-css-color": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+      "integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "hex-rgb": "^4.1.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -1954,7 +2221,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/preact": {
@@ -1984,6 +2250,25 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
       "license": "MIT"
+    },
+    "node_modules/prisma": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/engines": "5.22.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=16.13"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -2147,6 +2432,34 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/satori": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/satori/-/satori-0.12.2.tgz",
+      "integrity": "sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@shuding/opentype.js": "1.4.0-beta.0",
+        "css-background-parser": "^0.1.0",
+        "css-box-shadow": "1.0.0-3",
+        "css-gradient-parser": "^0.0.16",
+        "css-to-react-native": "^3.0.0",
+        "emoji-regex": "^10.2.1",
+        "escape-html": "^1.0.3",
+        "linebreak": "^1.1.0",
+        "parse-css-color": "^0.2.1",
+        "postcss-value-parser": "^4.2.0",
+        "yoga-wasm-web": "^0.3.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/satori/node_modules/emoji-regex": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2282,6 +2595,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string.prototype.codepointat": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+      "license": "MIT"
     },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
@@ -2472,6 +2791,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2569,6 +2894,16 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -2787,6 +3122,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yoga-wasm-web": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
+      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -8,9 +8,15 @@
     "next": "14.2.5",
     "next-auth": "4.24.11",
     "next-intl": "3.4.0",
+    "@prisma/client": "^5.16.1",
+    "date-fns": "^3.6.0",
+    "framer-motion": "^11.2.10",
     "react": "18.3.1",
     "react-chartjs-2": "5.2.0",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "zod": "^3.23.8",
+    "prisma": "^5.16.1",
+    "@vercel/og": "^0.6.2"
   },
   "devDependencies": {
     "@types/node": "22.15.30",
@@ -32,7 +38,8 @@
     "dev": "npm run setup && next dev",
     "build": "next build",
     "start": "next start",
-    "test": "node --require ts-node/register --test pages/api/auth/*.test.ts"
+    "test": "node --require ts-node/register --test pages/api/auth/*.test.ts",
+    "db:push": "prisma db push"
   },
   "version": "0.1.0"
 }

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -1,0 +1,89 @@
+// Prisma schema for ranking social features
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id
+  name      String?
+  email     String?  @unique
+  image     String?
+  handle    String?  @unique
+  bio       String?  @db.Text
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  rankings  Ranking[]
+  posts     Post[]
+  likes     Like[]
+  comments  Comment[]
+  following Follow[] @relation("following")
+  followers Follow[] @relation("followers")
+}
+
+model Ranking {
+  id         String   @id @default(cuid())
+  userId     String?
+  user       User?    @relation(fields: [userId], references: [id])
+  title      String
+  items      Json
+  criteria   Json
+  result     Json?
+  isPublic   Boolean  @default(false)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+  posts      Post[]
+}
+
+model Post {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  rankingId String
+  ranking   Ranking  @relation(fields: [rankingId], references: [id])
+  caption   String?  @db.Text
+  tags      String[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  likes     Like[]
+  comments  Comment[]
+}
+
+model Like {
+  id      String @id @default(cuid())
+  userId  String
+  postId  String
+
+  user    User @relation(fields: [userId], references: [id])
+  post    Post @relation(fields: [postId], references: [id])
+
+  @@unique([userId, postId])
+}
+
+model Comment {
+  id        String   @id @default(cuid())
+  userId    String
+  postId    String
+  body      String   @db.Text
+  createdAt DateTime @default(now())
+
+  user      User @relation(fields: [userId], references: [id])
+  post      Post @relation(fields: [postId], references: [id])
+}
+
+model Follow {
+  id          String @id @default(cuid())
+  followerId  String
+  followingId String
+
+  follower    User   @relation("followers", fields: [followerId], references: [id])
+  following   User   @relation("following", fields: [followingId], references: [id])
+
+  @@unique([followerId, followingId])
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -6,6 +6,10 @@
       "dom.iterable",
       "esnext"
     ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary
- extend database schema for users, posts, likes, comments, follows
- add Prisma client and NextAuth helpers
- implement initial social API routes and PostCard component

## Testing
- `npm test`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 DATABASE_URL="file:./dev.db" npm run db:push` *(fails: Failed to fetch the engine file)*


------
https://chatgpt.com/codex/tasks/task_e_689b9634a8dc83239e64895b6fcf6bb2