### PR TITLE
feat: enrich create page with template and drafts

### DIFF
--- a/web/app/api/rankings/route.ts
+++ b/web/app/api/rankings/route.ts
@@ -2,6 +2,26 @@ import { prisma } from '@/lib/prisma';
 import { NextResponse } from 'next/server';
 import { getServerSession } from '@/lib/auth';
 
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const me = searchParams.get('me');
+  const limit = searchParams.get('limit') ?? '6';
+  if (me === 'true') {
+    const s = await getServerSession();
+    if (!s?.user?.id) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+    const rows = await prisma.ranking.findMany({
+      where: { userId: s.user.id },
+      orderBy: { createdAt: 'desc' },
+      take: Number(limit),
+      select: { id: true, title: true, createdAt: true },
+    });
+    return NextResponse.json(rows);
+  }
+  return NextResponse.json({ error: 'not implemented' }, { status: 501 });
+}
+
 export async function POST(req: Request) {
   const s = await getServerSession();
   const { title, items, criteria, result, isPublic } = await req.json();

--- a/web/app/ja/create/page.tsx
+++ b/web/app/ja/create/page.tsx
@@ -1,53 +1,56 @@
-'use client';
-import { useState, useMemo } from 'react';
-import { motion } from 'framer-motion';
-import { Criterion } from '@/types/criteria';
-import CandidateCard from '@/components/create/CandidateCard';
-import CriteriaCard from '@/components/create/CriteriaCard';
-import PreviewCard from '@/components/create/PreviewCard';
-import TemplateCard from '@/components/create/TemplateCard';
+import { useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+import type { Criterion } from '@/types/criteria';
+
+const CandidateCard = dynamic(()=>import('@/components/create/CandidateCard'), { ssr:false });
+const CriteriaCard  = dynamic(()=>import('@/components/create/CriteriaCard'),  { ssr:false });
+const TemplateCard  = dynamic(()=>import('@/components/create/TemplateCard'),  { ssr:false });
+const PreviewCard   = dynamic(()=>import('@/components/create/PreviewCard'),   { ssr:false });
+const SampleSets    = dynamic(()=>import('@/components/create/SampleSets'),    { ssr:false });
+const RecentDrafts  = dynamic(()=>import('@/components/create/RecentDrafts'),  { ssr:false });
 
 export default function CreatePage() {
-  const [title, setTitle] = useState('');
-  const [items, setItems] = useState<{id:string;name:string;description?:string}[]>([{id:crypto.randomUUID(),name:''}]);
-  const [criteria, setCriteria] = useState<Criterion[]>([{
-    id: crypto.randomUUID(), name: '', type:'likert', weight:3, direction:'asc',
-    scale:{min:1,max:5,step:1,labels:['1','2','3','4','5']}
-  }]);
+  const [title,setTitle]=useState('');
+  const [items,setItems]=useState<{id:string;name:string;description?:string}[]>([
+    { id:crypto.randomUUID(), name:'' }
+  ]);
+  const [criteria,setCriteria]=useState<Criterion[]>([
+    { id:crypto.randomUUID(), name:'', type:'likert', weight:3, direction:'asc', scale:{min:1,max:5,step:1,labels:['1','2','3','4','5']} }
+  ]);
 
-  function onReorder(kind:'items'|'criteria', activeId:string, overId:string) {
-    const list = kind==='items'?items:criteria;
-    const idxA = list.findIndex(x=>x.id===activeId);
-    const idxB = list.findIndex(x=>x.id===overId);
-    if (idxA<0 || idxB<0) return;
-    const moved = [...list];
-    const [removed] = moved.splice(idxA,1);
-    moved.splice(idxB,0,removed);
-    kind==='items'? setItems(moved as any) : setCriteria(moved as any);
-  }
+  // （必要なら）ここでスコア計算
+  const result = useMemo(()=>({}), [items,criteria]);
 
-  const result = useMemo(()=>({}), [items, criteria]);
-
-  async function handleSave(isPublic:boolean) {
-    const res = await fetch('/api/rankings', {
+  async function handleSave(isPublic:boolean){
+    const res = await fetch('/api/rankings',{
       method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ title: title || '無題のランキング', items, criteria, result, isPublic })
     });
-    const { id } = await res.json();
-    location.href = `/r/${id}`;
+    const json = await res.json();
+    // 下書きを localStorage にも保存（フォールバック用）
+    try{
+      const arr = JSON.parse(localStorage.getItem('recent-rankings') || '[]');
+      arr.unshift({ id: json.id, title: title || '無題のランキング', createdAt: new Date().toISOString() });
+      localStorage.setItem('recent-rankings', JSON.stringify(arr.slice(0,6)));
+    }catch{}
+    location.href = `/r/${json.id}`;
   }
 
   return (
-    <div className="mx-auto max-w-6xl grid grid-cols-1 lg:grid-cols-2 gap-6 px-4 py-6">
-      <motion.div initial={{opacity:0,y:8}} animate={{opacity:1,y:0}} className="space-y-6">
-        <CandidateCard items={items} onChange={setItems} onReorder={(a,b)=>onReorder('items',a,b)} setTitle={setTitle} />
-        <CriteriaCard criteria={criteria} onChange={setCriteria} onReorder={(a,b)=>onReorder('criteria',a,b)} />
-        <TemplateCard onApply={(tpl)=>setCriteria(tpl)} />
-      </motion.div>
+    <main className="mx-auto max-w-6xl px-4 py-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* 左: 入力 */}
+      <section className="space-y-6">
+        <CandidateCard items={items} onChange={setItems} setTitle={setTitle}/>
+        <CriteriaCard criteria={criteria} onChange={setCriteria}/>
+        <TemplateCard onApply={setCriteria}/>
+        <SampleSets applyItems={setItems} applyCriteria={setCriteria}/>
+        <RecentDrafts/>
+      </section>
 
-      <motion.aside initial={{opacity:0,y:8}} animate={{opacity:1,y:0}} className="lg:sticky lg:top-6 h-fit">
-        <PreviewCard title={title} items={items} criteria={criteria} onSave={handleSave} />
-      </motion.aside>
-    </div>
+      {/* 右: プレビュー */}
+      <aside className="lg:sticky lg:top-6 h-fit">
+        <PreviewCard title={title} items={items} criteria={criteria} onSave={handleSave}/>
+      </aside>
+    </main>
   );
 }

--- a/web/app/ja/profile/page.tsx
+++ b/web/app/ja/profile/page.tsx
@@ -33,7 +33,7 @@ export default function ProfilePage(){
         </div>
       </div>
 
-      <CriteriaCard criteria={criteria} onChange={setCriteria} onReorder={()=>{}} />
+      <CriteriaCard criteria={criteria} onChange={setCriteria} />
 
       <div className="text-right">
         <button onClick={save} className="bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl px-6 py-3 shadow-lg">保存</button>

--- a/web/components/create/CandidateCard.tsx
+++ b/web/components/create/CandidateCard.tsx
@@ -1,35 +1,40 @@
 'use client';
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { DndContext, closestCenter } from '@dnd-kit/core';
-import { Draggable } from './Draggable';
+import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import Draggable from './Draggable';
 
-export default function CandidateCard({ items, onChange, onReorder, setTitle }:{
-  items:{id:string;name:string;description?:string}[];
-  onChange:(v:any)=>void; onReorder:(activeId:string, overId:string)=>void;
-  setTitle:(t:string)=>void;
+type Item = { id:string; name:string; description?:string };
+
+export default function CandidateCard({
+  items, onChange, setTitle,
+}:{
+  items: Item[];
+  onChange: (v: Item[]) => void;
+  setTitle: (t: string) => void;
 }) {
-  function add() { onChange([...items, { id:crypto.randomUUID(), name:'' }]); }
-  function update(id:string, patch:any){ onChange(items.map(i=>i.id===id?{...i,...patch}:i)); }
-  function remove(id:string){ onChange(items.filter(i=>i.id!==id)); }
+  function add() { onChange([...items, { id: crypto.randomUUID(), name: '' }]); }
+  function patch(id: string, p: Partial<Item>) { onChange(items.map(x => x.id===id? { ...x, ...p } : x)); }
+  function remove(id: string) { onChange(items.filter(x => x.id !== id)); }
+  function onDragEnd({active, over}: any){
+    if(over && active.id!==over.id){
+      const oldIndex=items.findIndex(i=>i.id===active.id);
+      const newIndex=items.findIndex(i=>i.id===over.id);
+      if(oldIndex>=0 && newIndex>=0) onChange(arrayMove(items, oldIndex, newIndex));
+    }
+  }
 
   return (
     <div className="rounded-2xl bg-white border border-slate-200 shadow-md p-4">
-      <input placeholder="タイトル（例: 東京ラーメン総合）"
-        onChange={e=>setTitle(e.target.value)} className="w-full rounded-xl border px-3 py-2 mb-3"/>
+      <input className="w-full rounded-xl border px-3 py-2 mb-3" placeholder="タイトル（例：東京ラーメン総合）" onChange={e=>setTitle(e.target.value)} />
       <h3 className="font-bold">比較候補</h3>
-      <DndContext collisionDetection={closestCenter} onDragEnd={({active, over})=>{
-        if(over && active.id!==over.id) onReorder(active.id as string, over.id as string);
-      }}>
+      <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
         <SortableContext items={items.map(i=>i.id)} strategy={verticalListSortingStrategy}>
           <div className="space-y-3 mt-3">
             {items.map(i=>(
               <Draggable id={i.id} key={i.id}>
                 <div className="rounded-xl border p-3 bg-slate-50">
-                  <input className="w-full rounded-lg border px-3 py-2 mb-2" placeholder="候補名"
-                    value={i.name} onChange={e=>update(i.id,{name:e.target.value})}/>
-                  <textarea className="w-full rounded-lg border px-3 py-2 text-sm" rows={2}
-                    placeholder="説明（任意）" value={i.description||''}
-                    onChange={e=>update(i.id,{description:e.target.value})}/>
+                  <input className="w-full rounded-lg border px-3 py-2 mb-2" placeholder="候補名" value={i.name} onChange={e=>patch(i.id, { name: e.target.value })}/>
+                  <textarea className="w-full rounded-lg border px-3 py-2 text-sm" rows={2} placeholder="説明（任意）" value={i.description||''} onChange={e=>patch(i.id, { description: e.target.value })}/>
                   <div className="text-right mt-2">
                     <button onClick={()=>remove(i.id)} className="text-rose-500 text-sm">削除</button>
                   </div>

--- a/web/components/create/CriteriaCard.tsx
+++ b/web/components/create/CriteriaCard.tsx
@@ -1,31 +1,38 @@
 'use client';
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { DndContext, closestCenter } from '@dnd-kit/core';
-import { Draggable } from './Draggable';
+import { SortableContext, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import Draggable from './Draggable';
 import type { Criterion } from '@/types/criteria';
 
-export default function CriteriaCard({ criteria, onChange, onReorder }:{
-  criteria: Criterion[]; onChange:(v:Criterion[])=>void;
-  onReorder:(activeId:string, overId:string)=>void;
+export default function CriteriaCard({
+  criteria, onChange,
+}:{
+  criteria: Criterion[];
+  onChange: (v: Criterion[]) => void;
 }) {
-  function add(){
+  function add() {
     onChange([...criteria, {
       id: crypto.randomUUID(), name:'', description:'',
       type:'likert', weight:3, direction:'asc',
-      scale:{min:1,max:5,step:1,labels:['1','2','3','4','5']}
+      scale:{ min:1, max:5, step:1, labels:['1','2','3','4','5'] },
     }]);
   }
-  function update(id:string, patch:Partial<Criterion>){
-    onChange(criteria.map(c=>c.id===id?{...c,...patch}:c));
+  function patch(id: string, p: Partial<Criterion>) {
+    onChange(criteria.map(c => c.id===id? { ...c, ...p } : c));
   }
-  function remove(id:string){ onChange(criteria.filter(c=>c.id!==id)); }
+  function remove(id: string) { onChange(criteria.filter(c => c.id !== id)); }
+  function onDragEnd({active, over}: any){
+    if(over && active.id!==over.id){
+      const oldIndex=criteria.findIndex(c=>c.id===active.id);
+      const newIndex=criteria.findIndex(c=>c.id===over.id);
+      if(oldIndex>=0 && newIndex>=0) onChange(arrayMove(criteria, oldIndex, newIndex));
+    }
+  }
 
   return (
     <div className="rounded-2xl bg-white border border-slate-200 shadow-md p-4">
       <h3 className="font-bold">評価基準</h3>
-      <DndContext collisionDetection={closestCenter} onDragEnd={({active, over})=>{
-        if(over && active.id!==over.id) onReorder(active.id as string, over.id as string);
-      }}>
+      <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
         <SortableContext items={criteria.map(c=>c.id)} strategy={verticalListSortingStrategy}>
           <div className="space-y-3 mt-3">
             {criteria.map(c=>(
@@ -33,42 +40,32 @@ export default function CriteriaCard({ criteria, onChange, onReorder }:{
                 <details className="rounded-xl border p-3 bg-slate-50" open>
                   <summary className="font-medium cursor-pointer">{c.name || '（未入力）'}</summary>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-3">
-                    <input className="rounded-lg border px-3 py-2" placeholder="基準名"
-                      value={c.name} onChange={e=>update(c.id,{name:e.target.value})}/>
-                    <select className="rounded-lg border px-3 py-2"
-                      value={c.type} onChange={e=>update(c.id,{type: e.target.value as any})}>
+                    <input className="rounded-lg border px-3 py-2" placeholder="基準名" value={c.name} onChange={e=>patch(c.id, { name: e.target.value })}/>
+                    <select className="rounded-lg border px-3 py-2" value={c.type} onChange={e=>patch(c.id, { type: e.target.value as any })}>
                       <option value="likert">Likert(1-5)</option>
                       <option value="number">数値</option>
                       <option value="boolean">Yes/No</option>
                       <option value="text">テキスト</option>
                     </select>
-                    <textarea className="md:col-span-2 rounded-lg border px-3 py-2" rows={2}
-                      placeholder="説明" value={c.description||''}
-                      onChange={e=>update(c.id,{description:e.target.value})}/>
+                    <textarea className="md:col-span-2 rounded-lg border px-3 py-2" rows={2} placeholder="説明" value={c.description||''} onChange={e=>patch(c.id, { description: e.target.value })}/>
                     <div className="rounded-lg border p-2">
                       <label className="text-sm text-slate-600">重み</label>
-                      <input type="range" min={1} max={10} value={c.weight}
-                        onChange={e=>update(c.id,{weight:Number(e.target.value)})} className="w-full"/>
+                      <input type="range" min={1} max={10} value={c.weight} onChange={e=>patch(c.id, { weight: Number(e.target.value) })} className="w-full"/>
                       <div className="text-right text-sm">{c.weight}</div>
                     </div>
                     <div className="rounded-lg border p-2">
                       <label className="text-sm text-slate-600">方向</label>
-                      <select value={c.direction}
-                        onChange={e=>update(c.id,{direction:e.target.value as any})} className="w-full rounded px-2 py-1 border">
+                      <select className="w-full rounded px-2 py-1 border" value={c.direction} onChange={e=>patch(c.id, { direction: e.target.value as any })}>
                         <option value="asc">高いほど良い</option>
                         <option value="desc">低いほど良い</option>
                       </select>
                     </div>
                     <div className="md:col-span-2 grid grid-cols-3 gap-2">
-                      <input className="rounded border px-2 py-1" type="number" step="0.1"
-                        value={c.scale?.min ?? 1} onChange={e=>update(c.id,{scale:{...c.scale, min:Number(e.target.value)}})} placeholder="最小"/>
-                      <input className="rounded border px-2 py-1" type="number" step="0.1"
-                        value={c.scale?.max ?? 5} onChange={e=>update(c.id,{scale:{...c.scale, max:Number(e.target.value)}})} placeholder="最大"/>
-                      <input className="rounded border px-2 py-1" type="number" step="0.1"
-                        value={c.scale?.step ?? 1} onChange={e=>update(c.id,{scale:{...c.scale, step:Number(e.target.value)}})} placeholder="刻み"/>
+                      <input className="rounded border px-2 py-1" type="number" step="0.1" value={c.scale?.min ?? 1} onChange={e=>patch(c.id,{ scale:{...c.scale, min:Number(e.target.value)} })} placeholder="最小"/>
+                      <input className="rounded border px-2 py-1" type="number" step="0.1" value={c.scale?.max ?? 5} onChange={e=>patch(c.id,{ scale:{...c.scale, max:Number(e.target.value)} })} placeholder="最大"/>
+                      <input className="rounded border px-2 py-1" type="number" step="0.1" value={c.scale?.step ?? 1} onChange={e=>patch(c.id,{ scale:{...c.scale, step:Number(e.target.value)} })} placeholder="刻み"/>
                     </div>
-                    <input className="md:col-span-2 rounded border px-2 py-1" placeholder="ラベル（カンマ区切り）"
-                      value={c.scale?.labels?.join(',') || ''} onChange={e=>update(c.id,{scale:{...c.scale, labels: e.target.value.split(',').map(s=>s.trim()).filter(Boolean)}})} />
+                    <input className="md:col-span-2 rounded border px-2 py-1" placeholder="ラベル（カンマ区切り）" value={c.scale?.labels?.join(',') || ''} onChange={e=>patch(c.id,{ scale:{...c.scale, labels:e.target.value.split(',').map(s=>s.trim()).filter(Boolean)} })} />
                   </div>
                   <div className="text-right mt-3">
                     <button onClick={()=>remove(c.id)} className="text-rose-500 text-sm">削除</button>

--- a/web/components/create/Draggable.tsx
+++ b/web/components/create/Draggable.tsx
@@ -2,13 +2,8 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
-export function Draggable({ id, children }:{id:string; children:any}) {
+export default function Draggable({ id, children }:{ id:string; children: React.ReactNode }) {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
-  const style:any = { transform: CSS.Transform.toString(transform), transition };
-  return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {children}
-    </div>
-  );
+  const style: React.CSSProperties = { transform: CSS.Transform.toString(transform), transition };
+  return <div ref={setNodeRef} style={style} {...attributes} {...listeners}>{children}</div>;
 }
-export default Draggable;

--- a/web/components/create/PreviewCard.tsx
+++ b/web/components/create/PreviewCard.tsx
@@ -1,21 +1,32 @@
 'use client';
-import { useState } from 'react';
+import { Bar } from 'react-chartjs-2';
+import { Chart as ChartJS, BarElement, CategoryScale, LinearScale, Tooltip, Legend } from 'chart.js';
+ChartJS.register(BarElement, CategoryScale, LinearScale, Tooltip, Legend);
 
-export default function PreviewCard({ title, items, criteria, onSave }:{
+export default function PreviewCard({
+  title, items, criteria, onSave,
+}:{
   title:string; items:any[]; criteria:any[]; onSave:(isPublic:boolean)=>void;
 }) {
-  const [isPublic, setIsPublic] = useState(true);
+  const labels = criteria.map((c:any)=>c.name || '（未設定）');
+  const data = {
+    labels,
+    datasets: [{ label: '重み', data: criteria.map((c:any)=>c.weight||0) }]
+  };
 
   return (
     <div className="rounded-2xl bg-white border border-slate-200 shadow-md p-4">
       <h3 className="font-bold mb-2">プレビュー / 保存</h3>
-      <div className="text-sm text-slate-600 mb-3">候補 {items.length} 件・基準 {criteria.length} 件</div>
-      {/* TODO: チャート/表  */}
-      <label className="flex items-center gap-2 mb-4">
-        <input type="checkbox" checked={isPublic} onChange={e=>setIsPublic(e.target.checked)} />
-        <span>公開する（共有可能）</span>
+      <div className="text-sm text-slate-600 mb-3">{title || '無題のランキング'} / 候補{items.length}件・基準{criteria.length}件</div>
+      <div className="rounded-xl border p-3 bg-slate-50 mb-3">
+        <Bar data={data} options={{ responsive:true, plugins:{ legend:{ display:false } } }}/>
+      </div>
+      <label className="flex items-center gap-2 my-3">
+        <input id="public" type="checkbox" defaultChecked />
+        <span>公開する（共有リンクを有効化）</span>
       </label>
-      <button onClick={()=>onSave(isPublic)} className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl py-3 shadow-lg">
+      <button onClick={()=>onSave((document.getElementById('public') as HTMLInputElement)?.checked ?? true)}
+        className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-2xl py-3 shadow-lg">
         ランキングを生成・保存
       </button>
     </div>

--- a/web/components/create/RecentDrafts.tsx
+++ b/web/components/create/RecentDrafts.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function RecentDrafts(){
+  const [rows,setRows]=useState<any[]>([]);
+  useEffect(()=>{
+    (async ()=>{
+      // もし /api/rankings?me=true が実装済みならそれを使用
+      const r = await fetch('/api/rankings?me=true&limit=6');
+      if(r.ok){ setRows(await r.json()); return; }
+      // フォールバック：localStorage
+      const raw = localStorage.getItem('recent-rankings');
+      if(raw) setRows(JSON.parse(raw));
+    })();
+  },[]);
+  if(!rows.length) return null;
+
+  return (
+    <div className="rounded-2xl bg-white border border-slate-200 shadow-md p-4">
+      <h3 className="font-bold mb-2">最近の下書き</h3>
+      <div className="grid md:grid-cols-2 gap-3">
+        {rows.map((x:any)=>(
+          <a key={x.id} href={`/r/${x.id}`} className="rounded-xl border p-3 bg-slate-50 hover:shadow">
+            <div className="font-medium">{x.title}</div>
+            <div className="text-xs text-slate-500 mt-1">{new Date(x.createdAt).toLocaleString()}</div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/components/create/SampleSets.tsx
+++ b/web/components/create/SampleSets.tsx
@@ -1,0 +1,28 @@
+'use client';
+import type { Criterion } from '@/types/criteria';
+
+export default function SampleSets({
+  applyItems, applyCriteria,
+}:{ applyItems:(v:any[])=>void; applyCriteria:(v:Criterion[])=>void }) {
+  function fillRamen(){
+    applyItems([
+      { id:crypto.randomUUID(), name:'ラーメン屋A', description:'魚介系・駅近' },
+      { id:crypto.randomUUID(), name:'ラーメン屋B', description:'豚骨・深夜営業' },
+      { id:crypto.randomUUID(), name:'ラーメン屋C', description:'醤油・老舗' },
+    ]);
+    applyCriteria([
+      { id:crypto.randomUUID(), name:'味', description:'総合的な味の良さ', type:'likert', weight:5, direction:'asc', scale:{min:1,max:5,step:1,labels:['1','2','3','4','5']} },
+      { id:crypto.randomUUID(), name:'価格', description:'コスパの良さ', type:'likert', weight:3, direction:'desc', scale:{min:1,max:5,step:1,labels:['高','やや高','普通','やや安','安']} },
+      { id:crypto.randomUUID(), name:'アクセス', description:'通いやすさ', type:'likert', weight:2, direction:'asc', scale:{min:1,max:5,step:1} },
+    ] as any);
+  }
+  return (
+    <div className="rounded-2xl bg-white border border-slate-200 shadow-md p-4">
+      <h3 className="font-bold mb-2">サンプルを入れる</h3>
+      <p className="text-sm text-slate-600">デモに便利。クリックで候補と評価基準を自動入力します。</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button onClick={fillRamen} className="rounded-2xl border px-4 py-2">ラーメンの例を入れる</button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/create/TemplateCard.tsx
+++ b/web/components/create/TemplateCard.tsx
@@ -12,7 +12,7 @@ export default function TemplateCard({ onApply }:{ onApply:(tpl:Criterion[])=>vo
   return (
     <div className="rounded-2xl bg-white border border-slate-200 shadow-md p-4">
       <h3 className="font-bold mb-2">テンプレート</h3>
-      <p className="text-sm text-slate-600">プロフィールに保存したデフォルト評価基準を適用できます。</p>
+      <p className="text-sm text-slate-600">プロフィール保存の「デフォルト評価基準」を適用できます。</p>
       <button disabled={!tpl} onClick={()=>tpl && onApply(tpl)} className="mt-3 rounded-2xl border px-4 py-2">
         {tpl ? 'デフォルト評価基準を読み込む' : 'デフォルト未設定'}
       </button>

--- a/web/types/criteria.ts
+++ b/web/types/criteria.ts
@@ -1,10 +1,16 @@
 export type CriterionType = 'number' | 'likert' | 'boolean' | 'text';
+
 export type Criterion = {
   id: string;
   name: string;
   description?: string;
   type: CriterionType;
-  weight: number;          // 1..10
-  direction: 'asc' | 'desc';
-  scale?: { min: number; max: number; step?: number; labels?: string[] }; // likert等
+  weight: number;              // 1..10
+  direction: 'asc' | 'desc';   // 高いほど良い / 低いほど良い
+  scale?: {                    // likert/number 用
+    min: number;
+    max: number;
+    step?: number;
+    labels?: string[];         // ラベル（Likertなど）
+  };
 };


### PR DESCRIPTION
## Summary
- overhaul JP create page with draggable candidate/criteria cards
- add template, sample set, preview and recent drafts widgets
- support ranking history via GET /api/rankings?me=true

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bac397e5c8323a280b4d0f3261194