### PR TITLE
Use client wrapper for language switcher

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,13 +1,15 @@
-"use client";
-
 import '../globals.css';
 import SessionProviderWrapper from './providers/SessionProviderWrapper';
+import ClientLanguageSwitcher from '../components/ClientLanguageSwitcher';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
       <body>
-        <SessionProviderWrapper>{children}</SessionProviderWrapper>
+        <SessionProviderWrapper>
+          <ClientLanguageSwitcher />
+          {children}
+        </SessionProviderWrapper>
       </body>
     </html>
   );

--- a/web/components/ClientLanguageSwitcher.tsx
+++ b/web/components/ClientLanguageSwitcher.tsx
@@ -1,9 +1,4 @@
-"use client";
-
-import LanguageSwitcher from "./LanguageSwitcher";
-
-export default function ClientLanguageSwitcher(
-  props: React.ComponentProps<typeof LanguageSwitcher>
-) {
-  return <LanguageSwitcher {...props} />;
-}
+'use client';
+import LanguageSwitcher from './LanguageSwitcher';
+const ClientLanguageSwitcher = (props: React.ComponentProps<typeof LanguageSwitcher>) => <LanguageSwitcher {...props} />;
+export default ClientLanguageSwitcher;

--- a/web/components/LanguageSwitcher.tsx
+++ b/web/components/LanguageSwitcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {useLocale} from 'next-intl';
-import {usePathname, useRouter} from 'next/navigation';
+import {usePathname, useRouter} from 'next-intl/client';
 
 const LOCALES = ['ja','en'] as const;
 


### PR DESCRIPTION
## Summary
- convert root layout to server component and import client-language switcher wrapper
- add minimal ClientLanguageSwitcher wrapper component
- remove favicon binary asset to avoid non-text file in repo
- use next-intl navigation hooks so language switcher works across routers

## Testing
- `rm -rf web/.next`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c8f7a60d4832387826cca2333db95