### PR TITLE
fix: update LanguageSwitcher navigation imports

### DIFF
--- a/web/components/LanguageSwitcher.tsx
+++ b/web/components/LanguageSwitcher.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import {useLocale} from 'next-intl';
-import {usePathname, useRouter} from 'next-intl/client';
+import {createSharedPathnamesNavigation} from 'next-intl/navigation';
 
 const LOCALES = ['ja','en'] as const;
+
+const {usePathname, useRouter} = createSharedPathnamesNavigation({locales: LOCALES});
 
 export default function LanguageSwitcher() {
   const locale = useLocale();


### PR DESCRIPTION
## Summary
- use next-intl navigation utilities instead of deprecated client import in LanguageSwitcher

## Testing
- `npm test`
- `npm run build` *(fails: Expected '>', got 'style' in app/api/og/post/[id]/route.ts; component requires useState in app/ja/create/page.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cde4bebe083239cad7668dd3dac48