### PR TITLE
fix: mount language switcher inside locale layout

### DIFF
--- a/web/app/ja/layout.tsx
+++ b/web/app/ja/layout.tsx
@@ -1,0 +1,10 @@
+import ClientLanguageSwitcher from '@/components/ClientLanguageSwitcher';
+
+export default function JaLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <ClientLanguageSwitcher />
+      {children}
+    </>
+  );
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,13 +1,11 @@
 import '../globals.css';
 import SessionProviderWrapper from './providers/SessionProviderWrapper';
-import ClientLanguageSwitcher from '../components/ClientLanguageSwitcher';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="ja">
       <body>
         <SessionProviderWrapper>
-          <ClientLanguageSwitcher />
           {children}
         </SessionProviderWrapper>
       </body>

--- a/web/components/LanguageSwitcher.tsx
+++ b/web/components/LanguageSwitcher.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import {useLocale} from 'next-intl';
-import {usePathname, useRouter} from 'next-intl/client';
+import {createSharedPathnamesNavigation} from 'next-intl/navigation';
 
 const LOCALES = ['ja','en'] as const;
+
+const {usePathname, useRouter} = createSharedPathnamesNavigation({locales: LOCALES});
 
 export default function LanguageSwitcher() {
   const locale = useLocale();


### PR DESCRIPTION
## Summary
- mount ClientLanguageSwitcher within ja layout to access router context
- drop language switcher from root layout

## Testing
- `npm test`
- `npm run build` *(fails: Expected '>', got 'style' in app/api/og/post/[id]/route.ts; component requires useState in app/ja/create/page.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689cde4bebe083239cad7668dd3dac48