### PR TITLE
chore(web): use react 18.2.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,9 +23,9 @@
         "next-auth": "4.24.11",
         "next-intl": "3.4.0",
         "prisma": "^5.16.1",
-        "react": "18.3.1",
+        "react": "18.2.0",
         "react-chartjs-2": "5.2.0",
-        "react-dom": "18.3.1",
+        "react-dom": "18.2.0",
         "react-hook-form": "^7.62.0",
         "zod": "^3.23.8"
       },
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -2380,16 +2380,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,9 +15,9 @@
     "next-auth": "4.24.11",
     "next-intl": "3.4.0",
     "prisma": "^5.16.1",
-    "react": "18.3.1",
+    "react": "18.2.0",
     "react-chartjs-2": "5.2.0",
-    "react-dom": "18.3.1",
+    "react-dom": "18.2.0",
     "react-hook-form": "^7.62.0",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
## Summary
- downgrade react and react-dom to 18.2.0 in web package

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cea35573883238ce2c06a8ac8c6e7