### PR TITLE
Enable Tailwind dark mode support

### DIFF
--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: "class",
   content: [
     "./app/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",


### PR DESCRIPTION
## Summary
- enable dark mode via `class` strategy in Tailwind config

## Testing
- `npm run build` *(fails: Expected '>', got 'style' in web/app/api/og/post/[id]/route.ts)*
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d4c3b9f308323801de451f4a77cef