### PR TITLE
chore(web): pin react type versions

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -24,8 +24,8 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",
     "@types/node": "^22.15.30",
-    "@types/react": "18.3.3",
-    "@types/react-dom": "18.3.3",
+    "@types/react": "18.2.79",
+    "@types/react-dom": "18.2.25",
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.4",
     "tailwindcss": "^3.3.5",
@@ -48,6 +48,8 @@
   "version": "0.1.0",
   "overrides": {
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@types/react": "18.2.79",
+    "@types/react-dom": "18.2.25"
   }
 }


### PR DESCRIPTION
## Summary
- pin @types/react and @types/react-dom to specific 18.2 releases
- lock react and react-dom along with their types via overrides

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d65a2a81083239a4f32c18071730b