### PR TITLE
fix language switcher client wrapping to resolve invalid hook call

### DIFF
--- a/web/app/ja/layout.tsx
+++ b/web/app/ja/layout.tsx
@@ -1,12 +1,12 @@
+import '../globals.css';
 import ClientLanguageSwitcher from '@/components/ClientLanguageSwitcher';
 
-export default function LocaleLayout({ children }: { children: React.ReactNode }) {
+export default function JaLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja" suppressHydrationWarning>
-      <body className="min-h-screen">
-        <ClientLanguageSwitcher />
-        {children}
-      </body>
-    </html>
+    <>
+      <ClientLanguageSwitcher />
+      {children}
+    </>
   );
 }
+

--- a/web/components/ClientLanguageSwitcher.tsx
+++ b/web/components/ClientLanguageSwitcher.tsx
@@ -2,6 +2,8 @@
 
 import LanguageSwitcher from './LanguageSwitcher';
 
-export default function ClientLanguageSwitcher() {
-  return <LanguageSwitcher />;
+export default function ClientLanguageSwitcher(
+  props: React.ComponentProps<typeof LanguageSwitcher>
+) {
+  return <LanguageSwitcher {...props} />;
 }

--- a/web/components/LanguageSwitcher.tsx
+++ b/web/components/LanguageSwitcher.tsx
@@ -10,7 +10,7 @@ export default function LanguageSwitcher() {
   const router = useRouter();
   const pathname = usePathname() ?? '/';
 
-  const switchTo = (target: typeof LOCALES[number]) => {
+  const switchTo = (target: (typeof LOCALES)[number]) => {
     const segs = pathname.split('/').filter(Boolean);
     if (LOCALES.includes(segs[0] as any)) segs[0] = target;
     else segs.unshift(target);
@@ -20,11 +20,7 @@ export default function LanguageSwitcher() {
   return (
     <div className="flex gap-2">
       {LOCALES.map(l => (
-        <button
-          key={l}
-          onClick={() => switchTo(l)}
-          className={`px-2 py-1 rounded ${l===locale ? 'bg-gray-200' : 'hover:bg-gray-100'}`}
-        >
+        <button key={l} onClick={() => switchTo(l)} className="px-2 py-1 rounded hover:bg-gray-100">
           {l}
         </button>
       ))}


### PR DESCRIPTION
## Summary
- simplify LanguageSwitcher and ensure it runs as a client component
- wrap ja layout with client language switcher to avoid server-client boundary issues
- forward props through ClientLanguageSwitcher

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: Cannot find module 'ts-node/register')*


------
https://chatgpt.com/codex/tasks/task_e_689d7bb0ae288323b75bb7a8b242597d