### PR TITLE
Refactor pages LanguageSwitcher for next/router

### DIFF
--- a/web/components/LanguageSwitcher.pages.tsx
+++ b/web/components/LanguageSwitcher.pages.tsx
@@ -2,22 +2,28 @@
 'use client';
 
 import { useLocale } from 'next-intl';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/router';
 
 const LOCALES = ['ja', 'en'] as const;
 
 export default function LanguageSwitcher() {
   const locale = useLocale();
   const router = useRouter();
-  const pathname = usePathname() ?? '/';
-  const searchParams = useSearchParams(); // 型では null 可能と見なされうる
 
   const switchTo = (target: (typeof LOCALES)[number]) => {
-    const segs = pathname.split('/').filter(Boolean);
+    const segs = router.pathname.split('/').filter(Boolean);
     if (LOCALES.includes(segs[0] as any)) segs[0] = target;
     else segs.unshift(target);
+
     const nextPath = '/' + segs.join('/');
-    const qs = searchParams?.toString() ?? '';
+
+    const params = new URLSearchParams();
+    Object.entries(router.query).forEach(([key, value]) => {
+      if (Array.isArray(value)) value.forEach((v) => params.append(key, v));
+      else if (value !== undefined) params.append(key, value);
+    });
+
+    const qs = params.toString();
     router.push(qs ? `${nextPath}?${qs}` : nextPath);
   };
 


### PR DESCRIPTION
## Summary
- refactor LanguageSwitcher.pages component to use `next/router`
- preserve query parameters when switching locales

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dffcffdc8832391dabc5c66fef6f8