### PR TITLE
chore: configure ESLint for Pages Router

### DIFF
--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  extends: ['next', 'next/core-web-vitals'],
+  overrides: [
+    {
+      files: ['pages/**/*.{ts,tsx}'],
+      rules: {
+        'no-restricted-imports': ['error', {
+          paths: [{ name: 'next/navigation', message: 'Pages Routerでは使用禁止。next/routerを使うこと。' }],
+        }],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- set up ESLint in `web` project extending Next.js defaults
- forbid importing `next/navigation` within `pages` and instruct to use `next/router`

## Testing
- `pytest`
- `cd web && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dffd36a688323ac35c1a295c3720e